### PR TITLE
[TOAZ-214][Bug] Sub and tenant Id's are not stored when creating a LZ.

### DIFF
--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateAzureLandingZoneDbRecordStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateAzureLandingZoneDbRecordStep.java
@@ -69,6 +69,8 @@ public class CreateAzureLandingZoneDbRecordStep implements Step {
             .displayName(requestedExternalLandingZoneResource.definition())
             .properties(requestedExternalLandingZoneResource.parameters())
             .resourceGroupId(landingZoneTarget.azureResourceGroupId())
+            .tenantId(landingZoneTarget.azureTenantId())
+            .subscriptionId(landingZoneTarget.azureSubscriptionId())
             .build());
     return StepResult.getStepResultSuccess();
   }


### PR DESCRIPTION
Added init for SubId and TenantId from Landing zone target object