### PR TITLE
[TOAZ-245] New auth flow for delete job results

### DIFF
--- a/service/src/main/java/bio/terra/landingzone/job/LandingZoneJobService.java
+++ b/service/src/main/java/bio/terra/landingzone/job/LandingZoneJobService.java
@@ -1,5 +1,7 @@
 package bio.terra.landingzone.job;
 
+import static bio.terra.landingzone.service.iam.LandingZoneSamService.IS_AUTHORIZED;
+
 import bio.terra.common.db.DataSourceInitializer;
 import bio.terra.common.iam.BearerToken;
 import bio.terra.common.logging.LoggingUtils;
@@ -356,6 +358,42 @@ public class LandingZoneJobService {
                   landingZoneId.toString(),
                   SamConstants.SamLandingZoneAction.LIST_RESOURCES),
           "isAuthorized");
+    } catch (DatabaseOperationException | InterruptedException ex) {
+      throw new InternalStairwayException("Stairway exception looking up the job", ex);
+    } catch (FlightNotFoundException ex) {
+      throw new JobNotFoundException("Job not found", ex);
+    }
+  }
+
+  public void verifyUserAccessForDeleteJobResult(
+      BearerToken bearerToken, UUID landingZoneId, String jobId) {
+    try {
+      FlightState flightState = stairwayComponent.get().getFlightState(jobId);
+      FlightMap inputParameters = flightState.getInputParameters();
+      UUID flightLandingZoneId =
+          inputParameters.get(LandingZoneFlightMapKeys.LANDING_ZONE_ID, UUID.class);
+      if (!flightLandingZoneId.equals(landingZoneId)) {
+        throw new JobNotFoundException(
+            "The landing zone does not exist for job or the landing zone id is invalid.");
+      }
+
+      // If the flight is completed successfully only check if the user is a valid SAM user
+      if (getJobStatus(flightState.getFlightStatus()).equals(JobReport.StatusEnum.SUCCEEDED)) {
+        SamRethrow.onInterrupted(
+            () -> samService.checkUserEnabled(bearerToken), "checkUserEnabled");
+        return;
+      }
+
+      // Check that the calling user has "list-delete" permission on the landing zone resource in
+      // Sam
+      SamRethrow.onInterrupted(
+          () ->
+              samService.checkAuthz(
+                  bearerToken,
+                  SamConstants.SamResourceType.LANDING_ZONE,
+                  landingZoneId.toString(),
+                  SamConstants.SamLandingZoneAction.DELETE),
+          IS_AUTHORIZED);
     } catch (DatabaseOperationException | InterruptedException ex) {
       throw new InternalStairwayException("Stairway exception looking up the job", ex);
     } catch (FlightNotFoundException ex) {

--- a/service/src/main/java/bio/terra/landingzone/job/LandingZoneJobService.java
+++ b/service/src/main/java/bio/terra/landingzone/job/LandingZoneJobService.java
@@ -368,6 +368,9 @@ public class LandingZoneJobService {
   public void verifyUserAccessForDeleteJobResult(
       BearerToken bearerToken, UUID landingZoneId, String jobId) {
     try {
+      // TODO: This flow must be updated to use the billing profile
+      // once the lz db has a reference to the billing profile.
+      // Ticket: TOAZ-246
       FlightState flightState = stairwayComponent.get().getFlightState(jobId);
       FlightMap inputParameters = flightState.getInputParameters();
       UUID flightLandingZoneId =

--- a/service/src/main/java/bio/terra/landingzone/service/iam/LandingZoneSamService.java
+++ b/service/src/main/java/bio/terra/landingzone/service/iam/LandingZoneSamService.java
@@ -33,6 +33,7 @@ public class LandingZoneSamService {
   private static final Logger logger = LoggerFactory.getLogger(LandingZoneSamService.class);
   private final LandingZoneSamConfiguration samConfig;
   private final OkHttpClient commonHttpClient;
+  public static final String IS_AUTHORIZED = "isAuthorized";
 
   @Autowired
   public LandingZoneSamService(LandingZoneSamConfiguration samConfig) {

--- a/service/src/main/java/bio/terra/landingzone/service/landingzone/azure/LandingZoneService.java
+++ b/service/src/main/java/bio/terra/landingzone/service/landingzone/azure/LandingZoneService.java
@@ -1,5 +1,7 @@
 package bio.terra.landingzone.service.landingzone.azure;
 
+import static bio.terra.landingzone.service.iam.LandingZoneSamService.IS_AUTHORIZED;
+
 import bio.terra.common.iam.BearerToken;
 import bio.terra.landingzone.db.LandingZoneDao;
 import bio.terra.landingzone.db.model.LandingZone;
@@ -48,7 +50,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class LandingZoneService {
   private static final Logger logger = LoggerFactory.getLogger(LandingZoneService.class);
-  public static final String IS_AUTHORIZED = "isAuthorized";
   private final LandingZoneJobService azureLandingZoneJobService;
   private final LandingZoneManagerProvider landingZoneManagerProvider;
   private final LandingZoneDao landingZoneDao;
@@ -86,13 +87,15 @@ public class LandingZoneService {
    * Retrieves the result of an asynchronous landing zone deleting job.
    *
    * @param bearerToken bearer token for the user request.
+   * @param landingZoneId landing zone id associated with the job.
    * @param jobId job identifier.
    * @return result of asynchronous job.
    */
   public AsyncJobResult<DeletedLandingZone> getAsyncDeletionJobResult(
-      BearerToken bearerToken, String jobId) {
+      BearerToken bearerToken, UUID landingZoneId, String jobId) {
     // Check calling user has access to the landing zone referenced by this job
-    azureLandingZoneJobService.verifyUserAccess(bearerToken, jobId);
+    azureLandingZoneJobService.verifyUserAccessForDeleteJobResult(
+        bearerToken, landingZoneId, jobId);
     return azureLandingZoneJobService.retrieveAsyncJobResult(jobId, DeletedLandingZone.class);
   }
 

--- a/service/src/test/java/bio/terra/landingzone/job/LandingZoneJobServiceTest.java
+++ b/service/src/test/java/bio/terra/landingzone/job/LandingZoneJobServiceTest.java
@@ -1,0 +1,127 @@
+package bio.terra.landingzone.job;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.iam.BearerToken;
+import bio.terra.common.stairway.StairwayComponent;
+import bio.terra.landingzone.common.utils.LandingZoneFlightBeanBag;
+import bio.terra.landingzone.job.exception.JobNotFoundException;
+import bio.terra.landingzone.library.configuration.LandingZoneIngressConfiguration;
+import bio.terra.landingzone.library.configuration.LandingZoneJobConfiguration;
+import bio.terra.landingzone.library.configuration.stairway.LandingZoneStairwayDatabaseConfiguration;
+import bio.terra.landingzone.service.iam.LandingZoneSamService;
+import bio.terra.landingzone.service.iam.SamConstants;
+import bio.terra.landingzone.stairway.common.utils.LandingZoneMdcHook;
+import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.FlightState;
+import bio.terra.stairway.FlightStatus;
+import bio.terra.stairway.Stairway;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("unit")
+class LandingZoneJobServiceTest {
+
+  private LandingZoneJobService landingZoneJobService;
+  @Mock private LandingZoneJobConfiguration jobConfig;
+  @Mock private LandingZoneIngressConfiguration ingressConfig;
+  @Mock private LandingZoneStairwayDatabaseConfiguration dbConfig;
+  @Mock private LandingZoneMdcHook mdcHook;
+  @Mock private StairwayComponent stairwayComponent;
+  @Mock private LandingZoneFlightBeanBag flightBeanBag;
+  @Mock private ObjectMapper mapper;
+  @Mock private LandingZoneSamService samService;
+  @Mock private Stairway stairwayInstance;
+
+  @Mock private FlightState flightState;
+
+  @Mock private FlightMap flightMap;
+
+  @Mock private BearerToken bearerToken;
+
+  @BeforeEach
+  void setUp() {
+    landingZoneJobService =
+        new LandingZoneJobService(
+            jobConfig,
+            ingressConfig,
+            dbConfig,
+            mdcHook,
+            stairwayComponent,
+            flightBeanBag,
+            mapper,
+            samService);
+  }
+
+  @Test
+  void verifyUserAccessForDeleteJobResult_jobSucceededValidSamUserIsChecked()
+      throws InterruptedException {
+    String jobId = "myjob";
+    UUID landingZoneId = UUID.randomUUID();
+    UUID flightLandingZoneId = landingZoneId;
+
+    when(stairwayComponent.get()).thenReturn(stairwayInstance);
+    when(stairwayInstance.getFlightState(jobId)).thenReturn(flightState);
+    when(flightState.getInputParameters()).thenReturn(flightMap);
+    when(flightState.getFlightStatus()).thenReturn(FlightStatus.SUCCESS);
+    when(flightMap.get(LandingZoneFlightMapKeys.LANDING_ZONE_ID, UUID.class))
+        .thenReturn(flightLandingZoneId);
+
+    landingZoneJobService.verifyUserAccessForDeleteJobResult(bearerToken, landingZoneId, jobId);
+  }
+
+  @Test
+  void verifyUserAccessForDeleteJobResult_landingZoneIdDoesNotMatchInIdFromJob()
+      throws InterruptedException {
+    String jobId = "myjob";
+    UUID landingZoneId = UUID.randomUUID();
+    UUID flightLandingZoneId = UUID.randomUUID();
+
+    when(stairwayComponent.get()).thenReturn(stairwayInstance);
+    when(stairwayInstance.getFlightState(jobId)).thenReturn(flightState);
+    when(flightState.getInputParameters()).thenReturn(flightMap);
+    when(flightMap.get(LandingZoneFlightMapKeys.LANDING_ZONE_ID, UUID.class))
+        .thenReturn(flightLandingZoneId);
+
+    assertThrows(
+        JobNotFoundException.class,
+        () ->
+            landingZoneJobService.verifyUserAccessForDeleteJobResult(
+                bearerToken, landingZoneId, jobId));
+  }
+
+  @Test
+  void verifyUserAccessForDeleteJobResult_jobIsRunningDeleteActionIsChecked()
+      throws InterruptedException {
+    String jobId = "myjob";
+    UUID landingZoneId = UUID.randomUUID();
+    UUID flightLandingZoneId = landingZoneId;
+
+    when(stairwayComponent.get()).thenReturn(stairwayInstance);
+    when(stairwayInstance.getFlightState(jobId)).thenReturn(flightState);
+    when(flightState.getInputParameters()).thenReturn(flightMap);
+    when(flightMap.get(LandingZoneFlightMapKeys.LANDING_ZONE_ID, UUID.class))
+        .thenReturn(flightLandingZoneId);
+    when(flightState.getFlightStatus()).thenReturn(FlightStatus.RUNNING);
+
+    landingZoneJobService.verifyUserAccessForDeleteJobResult(bearerToken, landingZoneId, jobId);
+
+    verify(samService, times(1))
+        .checkAuthz(
+            bearerToken,
+            SamConstants.SamResourceType.LANDING_ZONE,
+            landingZoneId.toString(),
+            SamConstants.SamLandingZoneAction.DELETE);
+  }
+}

--- a/service/src/test/java/bio/terra/landingzone/service/landingzone/azure/LandingZoneServiceTest.java
+++ b/service/src/test/java/bio/terra/landingzone/service/landingzone/azure/LandingZoneServiceTest.java
@@ -123,10 +123,29 @@ public class LandingZoneServiceTest {
   @Test
   void getAsyncDeletionJobResult_success() {
     String jobId = "newJobId";
-    landingZoneService.getAsyncDeletionJobResult(bearerToken, jobId);
+    UUID landingZoneId = UUID.randomUUID();
+    landingZoneService.getAsyncDeletionJobResult(bearerToken, landingZoneId, jobId);
 
     verify(landingZoneJobService, times(1))
         .retrieveAsyncJobResult(jobIdCaptor.capture(), classCaptor.capture());
+    verify(landingZoneJobService, times(1))
+        .verifyUserAccessForDeleteJobResult(bearerToken, landingZoneId, jobId);
+
+    assertEquals(jobId, jobIdCaptor.getValue());
+    assertEquals(DeletedLandingZone.class, classCaptor.getValue());
+  }
+
+  @Test
+  void getAsyncDeletionJobResult() {
+    String jobId = "newJobId";
+    UUID landingZoneId = UUID.randomUUID();
+    landingZoneService.getAsyncDeletionJobResult(bearerToken, landingZoneId, jobId);
+
+    verify(landingZoneJobService, times(1))
+        .retrieveAsyncJobResult(jobIdCaptor.capture(), classCaptor.capture());
+    verify(landingZoneJobService, times(1))
+        .verifyUserAccessForDeleteJobResult(bearerToken, landingZoneId, jobId);
+
     assertEquals(jobId, jobIdCaptor.getValue());
     assertEquals(DeletedLandingZone.class, classCaptor.getValue());
   }


### PR DESCRIPTION
- Delete job has the following auth flow:
  -  Checks if the landing zone id matches the job id in the flight/job, if not `JobNotFoundException` is thrown
  - If the flight is not in a success state, landing zone `delete` action is checked.
  - If the flight is in a success state, which means the sam resource is deleted, checks if the user is a valid sam user. 