### PR TITLE
TOAZ-227 create and use log analytics workspace

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-postgresql', version: '1.0.2'
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-loganalytics', version: '1.0.0-beta.3'
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-monitor', version: '2.20.0'
+    implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-applicationinsights', version: '1.0.0-beta.5'
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager', version: '2.15.0'
 
     liquibaseRuntime 'org.liquibase:liquibase-core:3.10.0'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-resources', version: '2.15.0'
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-batch', version: '1.0.0'
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-postgresql', version: '1.0.2'
+    implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-loganalytics', version: '1.0.0-beta.3'
+    implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-monitor', version: '2.20.0'
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager', version: '2.15.0'
 
     liquibaseRuntime 'org.liquibase:liquibase-core:3.10.0'

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/ArmManagers.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/ArmManagers.java
@@ -2,6 +2,8 @@ package bio.terra.landingzone.library.landingzones.definition;
 
 import com.azure.resourcemanager.AzureResourceManager;
 import com.azure.resourcemanager.batch.BatchManager;
+import com.azure.resourcemanager.loganalytics.LogAnalyticsManager;
+import com.azure.resourcemanager.monitor.MonitorManager;
 import com.azure.resourcemanager.postgresql.PostgreSqlManager;
 import com.azure.resourcemanager.relay.RelayManager;
 
@@ -10,4 +12,6 @@ public record ArmManagers(
     AzureResourceManager azureResourceManager,
     RelayManager relayManager,
     BatchManager batchManager,
-    PostgreSqlManager postgreSqlManager) {}
+    PostgreSqlManager postgreSqlManager,
+    LogAnalyticsManager logAnalyticsManager,
+    MonitorManager monitorManager) {}

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/ArmManagers.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/ArmManagers.java
@@ -1,6 +1,7 @@
 package bio.terra.landingzone.library.landingzones.definition;
 
 import com.azure.resourcemanager.AzureResourceManager;
+import com.azure.resourcemanager.applicationinsights.ApplicationInsightsManager;
 import com.azure.resourcemanager.batch.BatchManager;
 import com.azure.resourcemanager.loganalytics.LogAnalyticsManager;
 import com.azure.resourcemanager.monitor.MonitorManager;
@@ -14,4 +15,5 @@ public record ArmManagers(
     BatchManager batchManager,
     PostgreSqlManager postgreSqlManager,
     LogAnalyticsManager logAnalyticsManager,
-    MonitorManager monitorManager) {}
+    MonitorManager monitorManager,
+    ApplicationInsightsManager applicationInsightsManager) {}

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/ResourceNameGenerator.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/ResourceNameGenerator.java
@@ -29,6 +29,7 @@ public class ResourceNameGenerator {
   public static final int MAX_AKS_DNS_PREFIX_NAME_LENGTH = 54;
   public static final int MAX_DIAGNOSTIC_SETTING_NAME_LENGTH = 260;
   public static final int MAX_APP_INSIGHTS_COMPONENT_NAME_LENGTH = 255;
+  public static final int MAX_DATA_COLLECTION_RULE_NAME_LENGTH = 64;
 
   private final ClientLogger logger = new ClientLogger(ResourceNameGenerator.class);
   private final String landingZoneId;

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/ResourceNameGenerator.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/ResourceNameGenerator.java
@@ -28,6 +28,7 @@ public class ResourceNameGenerator {
   public static final int MAX_AKS_AGENT_POOL_NAME_LENGTH = 11;
   public static final int MAX_AKS_DNS_PREFIX_NAME_LENGTH = 54;
   public static final int MAX_DIAGNOSTIC_SETTING_NAME_LENGTH = 260;
+  public static final int MAX_APP_INSIGHTS_COMPONENT_NAME_LENGTH = 255;
 
   private final ClientLogger logger = new ClientLogger(ResourceNameGenerator.class);
   private final String landingZoneId;

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/ResourceNameGenerator.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/ResourceNameGenerator.java
@@ -16,6 +16,7 @@ public class ResourceNameGenerator {
   public static final int MAX_BATCH_ACCOUNT_NAME_LENGTH = 24;
   public static final int MAX_RELAY_NS_NAME_LENGTH = 50;
   public static final int MAX_POSTGRESQL_SERVER_NAME_LENGTH = 63;
+  public static final int MAX_LOG_ANALYTICS_WORKSPACE_NAME_LENGTH = 63;
   public static final int MAX_PRIVATE_ENDPOINT_NAME_LENGTH = 23; // TODO verify this
   public static final int MAX_PRIVATE_LINK_CONNECTION_NAME_LENGTH = 10; // TODO verify this
   // This is not the maximum value of 63. This lower value is to reduce the risk of deployment
@@ -26,6 +27,7 @@ public class ResourceNameGenerator {
   public static final int MAX_VNET_NAME_LENGTH = 64;
   public static final int MAX_AKS_AGENT_POOL_NAME_LENGTH = 11;
   public static final int MAX_AKS_DNS_PREFIX_NAME_LENGTH = 54;
+  public static final int MAX_DIAGNOSTIC_SETTING_NAME_LENGTH = 260;
 
   private final ClientLogger logger = new ClientLogger(ResourceNameGenerator.class);
   private final String landingZoneId;

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactory.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactory.java
@@ -11,6 +11,7 @@ import bio.terra.landingzone.library.landingzones.deployment.LandingZoneDeployme
 import bio.terra.landingzone.library.landingzones.deployment.LandingZoneDeployment.DefinitionStages.WithLandingZoneResource;
 import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
 import bio.terra.landingzone.library.landingzones.deployment.SubnetResourcePurpose;
+import bio.terra.landingzone.library.landingzones.management.AzureResourceTypeUtils;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.resourcemanager.AzureResourceManager;
 import com.azure.resourcemanager.applicationinsights.models.ApplicationType;
@@ -41,7 +42,7 @@ public class CromwellBaseResourcesFactory extends ArmClientsDefinitionFactory {
   private final String LZ_DESC =
       "Cromwell Base Resources: VNet, AKS Account & Nodepool, Batch Account,"
           + " Storage Account, PostgreSQL server, Subnets for AKS, Batch, Posgres, and Compute";
-  private final int AUDIT_LOG_RETENTION_DAYS = 365 * 2; // 2 years
+  private final int AUDIT_LOG_RETENTION_DAYS = 90;
 
   enum Subnet {
     AKS_SUBNET,
@@ -181,7 +182,7 @@ public class CromwellBaseResourcesFactory extends ArmClientsDefinitionFactory {
                   deployedResource ->
                       Objects.equals(
                           deployedResource.resourceType(),
-                          "Microsoft.OperationalInsights/workspaces"))
+                          AzureResourceTypeUtils.AZURE_LOG_ANALYTICS_WORKSPACE_TYPE))
               .findFirst()
               .get()
               .resourceId();
@@ -190,7 +191,7 @@ public class CromwellBaseResourcesFactory extends ArmClientsDefinitionFactory {
               .filter(
                   deployedResource ->
                       Objects.equals(
-                          deployedResource.resourceType(), "Microsoft.Network/virtualNetworks"))
+                          deployedResource.resourceType(), AzureResourceTypeUtils.AZURE_VNET_TYPE))
               .findFirst()
               .get()
               .resourceId();
@@ -199,7 +200,8 @@ public class CromwellBaseResourcesFactory extends ArmClientsDefinitionFactory {
               .filter(
                   deployedResource ->
                       Objects.equals(
-                          deployedResource.resourceType(), "Microsoft.DBforPostgreSQL/servers"))
+                          deployedResource.resourceType(),
+                          AzureResourceTypeUtils.AZURE_POSTGRESQL_SERVER_TYPE))
               .findFirst()
               .get()
               .resourceId();
@@ -208,7 +210,8 @@ public class CromwellBaseResourcesFactory extends ArmClientsDefinitionFactory {
               .filter(
                   deployedResource ->
                       Objects.equals(
-                          deployedResource.resourceType(), "Microsoft.Storage/storageAccounts"))
+                          deployedResource.resourceType(),
+                          AzureResourceTypeUtils.AZURE_STORAGE_ACCOUNT_TYPE))
               .findFirst()
               .get()
               .resourceId();

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactory.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactory.java
@@ -13,6 +13,7 @@ import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
 import bio.terra.landingzone.library.landingzones.deployment.SubnetResourcePurpose;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.resourcemanager.AzureResourceManager;
+import com.azure.resourcemanager.applicationinsights.models.ApplicationType;
 import com.azure.resourcemanager.containerservice.models.AgentPoolMode;
 import com.azure.resourcemanager.containerservice.models.ContainerServiceVMSizeTypes;
 import com.azure.resourcemanager.containerservice.models.ManagedClusterAddonProfile;
@@ -283,12 +284,26 @@ public class CromwellBaseResourcesFactory extends ArmClientsDefinitionFactory {
               .withLog("StorageWrite", 0)
               .withLog("StorageDelete", 0);
 
+      var appInsights =
+          armManagers
+              .applicationInsightsManager()
+              .components()
+              .define(
+                  nameGenerator.nextName(
+                      ResourceNameGenerator.MAX_APP_INSIGHTS_COMPONENT_NAME_LENGTH))
+              .withRegion(resourceGroup.region())
+              .withExistingResourceGroup(resourceGroup.name())
+              .withKind("java")
+              .withApplicationType(ApplicationType.OTHER)
+              .withWorkspaceResourceId(logAnalyticsWorkspaceId);
+
       return deployment
           .withResourceWithPurpose(aks, ResourcePurpose.SHARED_RESOURCE)
           .withResourceWithPurpose(batch, ResourcePurpose.SHARED_RESOURCE)
           .withResourceWithPurpose(relay, ResourcePurpose.SHARED_RESOURCE)
           .withResourceWithPurpose(privateEndpoint, ResourcePurpose.SHARED_RESOURCE)
-          .withResourceWithPurpose(storageAuditLogSettings, ResourcePurpose.SHARED_RESOURCE);
+          .withResourceWithPurpose(storageAuditLogSettings, ResourcePurpose.SHARED_RESOURCE)
+          .withResourceWithPurpose(appInsights, ResourcePurpose.SHARED_RESOURCE);
     }
 
     private Map<String, String> getDefaultParameters() {

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/deployment/LandingZoneDeployment.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/deployment/LandingZoneDeployment.java
@@ -1,5 +1,6 @@
 package bio.terra.landingzone.library.landingzones.deployment;
 
+import com.azure.resourcemanager.applicationinsights.models.ApplicationInsightsComponent;
 import com.azure.resourcemanager.batch.models.BatchAccount;
 import com.azure.resourcemanager.loganalytics.models.Workspace;
 import com.azure.resourcemanager.monitor.models.DiagnosticSetting;
@@ -52,7 +53,11 @@ public interface LandingZoneDeployment {
           ResourcePurpose sharedResource);
 
       Deployable withResourceWithPurpose(
-          DiagnosticSetting.DefinitionStages.WithCreate logAnalyticsWorkspace,
+          DiagnosticSetting.DefinitionStages.WithCreate diagnosticSettings,
+          ResourcePurpose sharedResource);
+
+      Deployable withResourceWithPurpose(
+          ApplicationInsightsComponent.DefinitionStages.WithCreate appInsights,
           ResourcePurpose sharedResource);
 
       WithLandingZoneResource definePrerequisites();

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/deployment/LandingZoneDeployment.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/deployment/LandingZoneDeployment.java
@@ -1,6 +1,8 @@
 package bio.terra.landingzone.library.landingzones.deployment;
 
 import com.azure.resourcemanager.batch.models.BatchAccount;
+import com.azure.resourcemanager.loganalytics.models.Workspace;
+import com.azure.resourcemanager.monitor.models.DiagnosticSetting;
 import com.azure.resourcemanager.network.models.Network;
 import com.azure.resourcemanager.network.models.PrivateEndpoint;
 import com.azure.resourcemanager.postgresql.models.Server;
@@ -43,6 +45,14 @@ public interface LandingZoneDeployment {
 
       Deployable withResourceWithPurpose(
           PrivateEndpoint.DefinitionStages.WithCreate privateEndpoint,
+          ResourcePurpose sharedResource);
+
+      Deployable withResourceWithPurpose(
+          Workspace.DefinitionStages.WithCreate logAnalyticsWorkspace,
+          ResourcePurpose sharedResource);
+
+      Deployable withResourceWithPurpose(
+          DiagnosticSetting.DefinitionStages.WithCreate logAnalyticsWorkspace,
           ResourcePurpose sharedResource);
 
       WithLandingZoneResource definePrerequisites();

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/deployment/ResourcesTagMapWrapper.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/deployment/ResourcesTagMapWrapper.java
@@ -2,6 +2,8 @@ package bio.terra.landingzone.library.landingzones.deployment;
 
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.resourcemanager.batch.models.BatchAccount;
+import com.azure.resourcemanager.loganalytics.models.Workspace;
+import com.azure.resourcemanager.monitor.models.DiagnosticSetting;
 import com.azure.resourcemanager.network.models.Network;
 import com.azure.resourcemanager.network.models.PrivateEndpoint;
 import com.azure.resourcemanager.postgresql.models.Server;
@@ -25,6 +27,10 @@ public class ResourcesTagMapWrapper {
       postgresResourcesTagsMap = new HashMap<>();
   private final Map<PrivateEndpoint.DefinitionStages.WithCreate, Map<String, String>>
       privateEndpointResourcesTagsMap = new HashMap<>();
+  private final Map<Workspace.DefinitionStages.WithCreate, Map<String, String>>
+      logAnalyticsWorkspaceResourcesTagsMap = new HashMap<>();
+  private final Map<DiagnosticSetting.DefinitionStages.WithCreate, Map<String, String>>
+      diagnosticSettingResourcesTagsMap = new HashMap<>();
   private final ClientLogger logger = new ClientLogger(ResourcesTagMapWrapper.class);
   private final String landingZoneId;
 
@@ -92,6 +98,16 @@ public class ResourcesTagMapWrapper {
     return privateEndpointResourcesTagsMap;
   }
 
+  Map<Workspace.DefinitionStages.WithCreate, Map<String, String>>
+      getLogAnalyticsWorkspaceResourcesTagsMap() {
+    return logAnalyticsWorkspaceResourcesTagsMap;
+  }
+
+  Map<DiagnosticSetting.DefinitionStages.WithCreate, Map<String, String>>
+      getDiagnosticSettingResourcesTagsMap() {
+    return diagnosticSettingResourcesTagsMap;
+  }
+
   Map<String, String> getResourceTagsMap(Creatable<?> resource) {
     return resourcesTagsMap.get(resource);
   }
@@ -130,6 +146,23 @@ public class ResourcesTagMapWrapper {
     putTagKeyValue(privateEndpoint, LandingZoneTagKeys.LANDING_ZONE_ID.toString(), landingZoneId);
     putTagKeyValue(
         privateEndpoint, LandingZoneTagKeys.LANDING_ZONE_PURPOSE.toString(), purpose.toString());
+  }
+
+  void putWithPurpose(
+      Workspace.DefinitionStages.WithCreate logAnalyticsWorkspace, ResourcePurpose purpose) {
+    putTagKeyValue(
+        logAnalyticsWorkspace, LandingZoneTagKeys.LANDING_ZONE_ID.toString(), landingZoneId);
+    putTagKeyValue(
+        logAnalyticsWorkspace,
+        LandingZoneTagKeys.LANDING_ZONE_PURPOSE.toString(),
+        purpose.toString());
+  }
+
+  void putWithPurpose(
+      DiagnosticSetting.DefinitionStages.WithCreate diagnosticSetting, ResourcePurpose purpose) {
+    putTagKeyValue(diagnosticSetting, LandingZoneTagKeys.LANDING_ZONE_ID.toString(), landingZoneId);
+    putTagKeyValue(
+        diagnosticSetting, LandingZoneTagKeys.LANDING_ZONE_PURPOSE.toString(), purpose.toString());
   }
 
   private void putTagKeyValue(
@@ -174,5 +207,27 @@ public class ResourcesTagMapWrapper {
 
     tagMap.put(key, value);
     privateEndpointResourcesTagsMap.put(privateEndpoint, tagMap);
+  }
+
+  private void putTagKeyValue(
+      Workspace.DefinitionStages.WithCreate logAnalyticsWorkspace, String key, String value) {
+    Map<String, String> tagMap = logAnalyticsWorkspaceResourcesTagsMap.get(logAnalyticsWorkspace);
+    if (tagMap == null) {
+      tagMap = new HashMap<>();
+    }
+
+    tagMap.put(key, value);
+    logAnalyticsWorkspaceResourcesTagsMap.put(logAnalyticsWorkspace, tagMap);
+  }
+
+  private void putTagKeyValue(
+      DiagnosticSetting.DefinitionStages.WithCreate diagnosticSetting, String key, String value) {
+    Map<String, String> tagMap = diagnosticSettingResourcesTagsMap.get(diagnosticSetting);
+    if (tagMap == null) {
+      tagMap = new HashMap<>();
+    }
+
+    tagMap.put(key, value);
+    diagnosticSettingResourcesTagsMap.put(diagnosticSetting, tagMap);
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/deployment/ResourcesTagMapWrapper.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/deployment/ResourcesTagMapWrapper.java
@@ -1,6 +1,7 @@
 package bio.terra.landingzone.library.landingzones.deployment;
 
 import com.azure.core.util.logging.ClientLogger;
+import com.azure.resourcemanager.applicationinsights.models.ApplicationInsightsComponent;
 import com.azure.resourcemanager.batch.models.BatchAccount;
 import com.azure.resourcemanager.loganalytics.models.Workspace;
 import com.azure.resourcemanager.monitor.models.DiagnosticSetting;
@@ -31,6 +32,8 @@ public class ResourcesTagMapWrapper {
       logAnalyticsWorkspaceResourcesTagsMap = new HashMap<>();
   private final Map<DiagnosticSetting.DefinitionStages.WithCreate, Map<String, String>>
       diagnosticSettingResourcesTagsMap = new HashMap<>();
+  private final Map<ApplicationInsightsComponent.DefinitionStages.WithCreate, Map<String, String>>
+      appInsightsResourcesTagsMap = new HashMap<>();
   private final ClientLogger logger = new ClientLogger(ResourcesTagMapWrapper.class);
   private final String landingZoneId;
 
@@ -108,6 +111,11 @@ public class ResourcesTagMapWrapper {
     return diagnosticSettingResourcesTagsMap;
   }
 
+  Map<ApplicationInsightsComponent.DefinitionStages.WithCreate, Map<String, String>>
+      getAppInsightsResourcesTagsMap() {
+    return appInsightsResourcesTagsMap;
+  }
+
   Map<String, String> getResourceTagsMap(Creatable<?> resource) {
     return resourcesTagsMap.get(resource);
   }
@@ -163,6 +171,14 @@ public class ResourcesTagMapWrapper {
     putTagKeyValue(diagnosticSetting, LandingZoneTagKeys.LANDING_ZONE_ID.toString(), landingZoneId);
     putTagKeyValue(
         diagnosticSetting, LandingZoneTagKeys.LANDING_ZONE_PURPOSE.toString(), purpose.toString());
+  }
+
+  void putWithPurpose(
+      ApplicationInsightsComponent.DefinitionStages.WithCreate appInsights,
+      ResourcePurpose purpose) {
+    putTagKeyValue(appInsights, LandingZoneTagKeys.LANDING_ZONE_ID.toString(), landingZoneId);
+    putTagKeyValue(
+        appInsights, LandingZoneTagKeys.LANDING_ZONE_PURPOSE.toString(), purpose.toString());
   }
 
   private void putTagKeyValue(
@@ -229,5 +245,18 @@ public class ResourcesTagMapWrapper {
 
     tagMap.put(key, value);
     diagnosticSettingResourcesTagsMap.put(diagnosticSetting, tagMap);
+  }
+
+  private void putTagKeyValue(
+      ApplicationInsightsComponent.DefinitionStages.WithCreate appInsights,
+      String key,
+      String value) {
+    Map<String, String> tagMap = appInsightsResourcesTagsMap.get(appInsights);
+    if (tagMap == null) {
+      tagMap = new HashMap<>();
+    }
+
+    tagMap.put(key, value);
+    appInsightsResourcesTagsMap.put(appInsights, tagMap);
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/management/AzureResourceTypeUtils.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/management/AzureResourceTypeUtils.java
@@ -3,11 +3,13 @@ package bio.terra.landingzone.library.landingzones.management;
 public class AzureResourceTypeUtils {
   private AzureResourceTypeUtils() {}
 
-  public static final String AZURE_VM_TYPE = "Microsoft.Network/virtualNetworks";
+  public static final String AZURE_VNET_TYPE = "Microsoft.Network/virtualNetworks";
   public static final String AZURE_RELAY_TYPE = "Microsoft.Relay/namespaces";
 
   public static final String AZURE_STORAGE_ACCOUNT_TYPE = "Microsoft.Storage/storageAccounts";
   public static final String AZURE_POSTGRESQL_SERVER_TYPE = "Microsoft.DBforPostgreSQL/servers";
   public static final String AZURE_AKS_TYPE = "Microsoft.ContainerService/managedClusters";
   public static final String AZURE_BATCH_TYPE = "Microsoft.Batch/batchAccounts";
+  public static final String AZURE_LOG_ANALYTICS_WORKSPACE_TYPE =
+      "Microsoft.OperationalInsights/workspaces";
 }

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/management/LandingZoneManager.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/management/LandingZoneManager.java
@@ -17,6 +17,7 @@ import com.azure.core.credential.TokenCredential;
 import com.azure.core.management.profile.AzureProfile;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.resourcemanager.AzureResourceManager;
+import com.azure.resourcemanager.applicationinsights.ApplicationInsightsManager;
 import com.azure.resourcemanager.batch.BatchManager;
 import com.azure.resourcemanager.loganalytics.LogAnalyticsManager;
 import com.azure.resourcemanager.monitor.MonitorManager;
@@ -90,6 +91,8 @@ public class LandingZoneManager {
     PostgreSqlManager postgreSqlManager = PostgreSqlManager.authenticate(credential, profile);
     LogAnalyticsManager logAnalyticsManager = LogAnalyticsManager.authenticate(credential, profile);
     MonitorManager monitorManager = MonitorManager.authenticate(credential, profile);
+    ApplicationInsightsManager applicationInsightsManager =
+        ApplicationInsightsManager.authenticate(credential, profile);
 
     return new ArmManagers(
         azureResourceManager,
@@ -97,7 +100,8 @@ public class LandingZoneManager {
         batchManager,
         postgreSqlManager,
         logAnalyticsManager,
-        monitorManager);
+        monitorManager,
+        applicationInsightsManager);
   }
 
   public static List<FactoryDefinitionInfo> listDefinitionFactories() {

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/management/LandingZoneManager.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/management/LandingZoneManager.java
@@ -18,6 +18,8 @@ import com.azure.core.management.profile.AzureProfile;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.resourcemanager.AzureResourceManager;
 import com.azure.resourcemanager.batch.BatchManager;
+import com.azure.resourcemanager.loganalytics.LogAnalyticsManager;
+import com.azure.resourcemanager.monitor.MonitorManager;
 import com.azure.resourcemanager.postgresql.PostgreSqlManager;
 import com.azure.resourcemanager.relay.RelayManager;
 import com.azure.resourcemanager.resources.fluentcore.arm.models.HasId;
@@ -86,8 +88,16 @@ public class LandingZoneManager {
     RelayManager relayManager = RelayManager.authenticate(credential, profile);
     BatchManager batchManager = BatchManager.authenticate(credential, profile);
     PostgreSqlManager postgreSqlManager = PostgreSqlManager.authenticate(credential, profile);
+    LogAnalyticsManager logAnalyticsManager = LogAnalyticsManager.authenticate(credential, profile);
+    MonitorManager monitorManager = MonitorManager.authenticate(credential, profile);
 
-    return new ArmManagers(azureResourceManager, relayManager, batchManager, postgreSqlManager);
+    return new ArmManagers(
+        azureResourceManager,
+        relayManager,
+        batchManager,
+        postgreSqlManager,
+        logAnalyticsManager,
+        monitorManager);
   }
 
   public static List<FactoryDefinitionInfo> listDefinitionFactories() {

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/management/ResourceToDelete.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/management/ResourceToDelete.java
@@ -9,4 +9,5 @@ import com.azure.resourcemanager.resources.models.GenericResource;
  * @param resource resource to delete.
  * @param privateEndpoint private endpoint associated with the resource.
  */
-public record ResourceToDelete(GenericResource resource, PrivateEndpoint privateEndpoint) {}
+public record ResourceToDelete(
+    GenericResource resource, PrivateEndpoint privateEndpoint, GenericResource solution) {}

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/management/deleterules/VmsAreAttachedToVnet.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/management/deleterules/VmsAreAttachedToVnet.java
@@ -1,6 +1,6 @@
 package bio.terra.landingzone.library.landingzones.management.deleterules;
 
-import static bio.terra.landingzone.library.landingzones.management.AzureResourceTypeUtils.AZURE_VM_TYPE;
+import static bio.terra.landingzone.library.landingzones.management.AzureResourceTypeUtils.AZURE_VNET_TYPE;
 
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.management.ResourceToDelete;
@@ -13,7 +13,7 @@ public class VmsAreAttachedToVnet extends ResourceDependencyDeleteRule {
 
   @Override
   public String getExpectedType() {
-    return AZURE_VM_TYPE;
+    return AZURE_VNET_TYPE;
   }
 
   @Override

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/LandingZoneTestFixture.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/LandingZoneTestFixture.java
@@ -22,7 +22,9 @@ public class LandingZoneTestFixture {
             TestArmResourcesFactory.createArmClient(),
             TestArmResourcesFactory.createRelayArmClient(),
             TestArmResourcesFactory.createBatchArmClient(),
-            TestArmResourcesFactory.createPostgreSqlArmClient());
+            TestArmResourcesFactory.createPostgreSqlArmClient(),
+            TestArmResourcesFactory.createLogAnalyticsArmClient(),
+            TestArmResourcesFactory.createMonitorArmClient());
     resourceGroup =
         TestArmResourcesFactory.createTestResourceGroup(armManagers.azureResourceManager());
     tokenCredential = AzureIntegrationUtils.getAdminAzureCredentialsOrDie();

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/LandingZoneTestFixture.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/LandingZoneTestFixture.java
@@ -24,7 +24,8 @@ public class LandingZoneTestFixture {
             TestArmResourcesFactory.createBatchArmClient(),
             TestArmResourcesFactory.createPostgreSqlArmClient(),
             TestArmResourcesFactory.createLogAnalyticsArmClient(),
-            TestArmResourcesFactory.createMonitorArmClient());
+            TestArmResourcesFactory.createMonitorArmClient(),
+            TestArmResourcesFactory.createApplicationInsightsArmClient());
     resourceGroup =
         TestArmResourcesFactory.createTestResourceGroup(armManagers.azureResourceManager());
     tokenCredential = AzureIntegrationUtils.getAdminAzureCredentialsOrDie();

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/TestArmResourcesFactory.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/TestArmResourcesFactory.java
@@ -5,6 +5,8 @@ import com.azure.core.management.Region;
 import com.azure.core.management.profile.AzureProfile;
 import com.azure.resourcemanager.AzureResourceManager;
 import com.azure.resourcemanager.batch.BatchManager;
+import com.azure.resourcemanager.loganalytics.LogAnalyticsManager;
+import com.azure.resourcemanager.monitor.MonitorManager;
 import com.azure.resourcemanager.postgresql.PostgreSqlManager;
 import com.azure.resourcemanager.relay.RelayManager;
 import com.azure.resourcemanager.resources.models.ResourceGroup;
@@ -25,7 +27,9 @@ public class TestArmResourcesFactory {
         createArmClient(),
         createRelayArmClient(),
         createBatchArmClient(),
-        createPostgreSqlArmClient());
+        createPostgreSqlArmClient(),
+        createLogAnalyticsArmClient(),
+        createMonitorArmClient());
   }
 
   public static RelayManager createRelayArmClient() {
@@ -42,6 +46,18 @@ public class TestArmResourcesFactory {
 
   public static PostgreSqlManager createPostgreSqlArmClient() {
     return PostgreSqlManager.authenticate(
+        AzureIntegrationUtils.getAdminAzureCredentialsOrDie(),
+        AzureIntegrationUtils.TERRA_DEV_AZURE_PROFILE);
+  }
+
+  public static LogAnalyticsManager createLogAnalyticsArmClient() {
+    return LogAnalyticsManager.authenticate(
+        AzureIntegrationUtils.getAdminAzureCredentialsOrDie(),
+        AzureIntegrationUtils.TERRA_DEV_AZURE_PROFILE);
+  }
+
+  public static MonitorManager createMonitorArmClient() {
+    return MonitorManager.authenticate(
         AzureIntegrationUtils.getAdminAzureCredentialsOrDie(),
         AzureIntegrationUtils.TERRA_DEV_AZURE_PROFILE);
   }

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/TestArmResourcesFactory.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/TestArmResourcesFactory.java
@@ -4,6 +4,7 @@ import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import com.azure.core.management.Region;
 import com.azure.core.management.profile.AzureProfile;
 import com.azure.resourcemanager.AzureResourceManager;
+import com.azure.resourcemanager.applicationinsights.ApplicationInsightsManager;
 import com.azure.resourcemanager.batch.BatchManager;
 import com.azure.resourcemanager.loganalytics.LogAnalyticsManager;
 import com.azure.resourcemanager.monitor.MonitorManager;
@@ -29,7 +30,8 @@ public class TestArmResourcesFactory {
         createBatchArmClient(),
         createPostgreSqlArmClient(),
         createLogAnalyticsArmClient(),
-        createMonitorArmClient());
+        createMonitorArmClient(),
+        createApplicationInsightsArmClient());
   }
 
   public static RelayManager createRelayArmClient() {
@@ -58,6 +60,12 @@ public class TestArmResourcesFactory {
 
   public static MonitorManager createMonitorArmClient() {
     return MonitorManager.authenticate(
+        AzureIntegrationUtils.getAdminAzureCredentialsOrDie(),
+        AzureIntegrationUtils.TERRA_DEV_AZURE_PROFILE);
+  }
+
+  public static ApplicationInsightsManager createApplicationInsightsArmClient() {
+    return ApplicationInsightsManager.authenticate(
         AzureIntegrationUtils.getAdminAzureCredentialsOrDie(),
         AzureIntegrationUtils.TERRA_DEV_AZURE_PROFILE);
   }

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactoryTest.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactoryTest.java
@@ -54,7 +54,7 @@ class CromwellBaseResourcesFactoryTest extends LandingZoneTestFixture {
     // check if you can read lz resources
     TimeUnit.SECONDS.sleep(3); // wait for tag propagation...
     var sharedResources = landingZoneManager.reader().listSharedResources(landingZoneId);
-    assertThat(sharedResources, hasSize(5));
+    assertThat(sharedResources, hasSize(6));
 
     assertHasVnetWithPurpose(landingZoneId, SubnetResourcePurpose.WORKSPACE_COMPUTE_SUBNET);
     assertHasVnetWithPurpose(landingZoneId, SubnetResourcePurpose.AKS_NODE_POOL_SUBNET);

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactoryTest.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactoryTest.java
@@ -84,16 +84,14 @@ class CromwellBaseResourcesFactoryTest extends LandingZoneTestFixture {
     await()
         .atMost(Duration.ofSeconds(120))
         .until(
-            () ->
-            {
-              Stream<GenericResource> stream = armManagers
-                  .azureResourceManager()
-                  .genericResources()
-                  .listByResourceGroup(resourceGroup.name())
-                  .stream();
-              return stream
-                      .count()
-                  == 0;
+            () -> {
+              Stream<GenericResource> stream =
+                  armManagers
+                      .azureResourceManager()
+                      .genericResources()
+                      .listByResourceGroup(resourceGroup.name())
+                      .stream();
+              return stream.count() == 0;
             });
   }
 

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactoryTest.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactoryTest.java
@@ -9,9 +9,11 @@ import bio.terra.landingzone.library.landingzones.definition.DefinitionVersion;
 import bio.terra.landingzone.library.landingzones.deployment.SubnetResourcePurpose;
 import bio.terra.landingzone.library.landingzones.management.LandingZoneManager;
 import bio.terra.landingzone.library.landingzones.management.deleterules.LandingZoneRuleDeleteException;
+import com.azure.resourcemanager.resources.models.GenericResource;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,12 +51,12 @@ class CromwellBaseResourcesFactoryTest extends LandingZoneTestFixture {
             .block();
 
     // Note that this resource list does not include pre-requisite resources
-    assertThat(resources, hasSize(5));
+    assertThat(resources, hasSize(6));
 
     // check if you can read lz resources
     TimeUnit.SECONDS.sleep(3); // wait for tag propagation...
     var sharedResources = landingZoneManager.reader().listSharedResources(landingZoneId);
-    assertThat(sharedResources, hasSize(6));
+    assertThat(sharedResources, hasSize(7));
 
     assertHasVnetWithPurpose(landingZoneId, SubnetResourcePurpose.WORKSPACE_COMPUTE_SUBNET);
     assertHasVnetWithPurpose(landingZoneId, SubnetResourcePurpose.AKS_NODE_POOL_SUBNET);
@@ -80,16 +82,19 @@ class CromwellBaseResourcesFactoryTest extends LandingZoneTestFixture {
 
     // Immediate listing after deletion may return transient resources results.
     await()
-        .atMost(Duration.ofSeconds(60))
+        .atMost(Duration.ofSeconds(120))
         .until(
             () ->
-                armManagers
-                        .azureResourceManager()
-                        .genericResources()
-                        .listByResourceGroup(resourceGroup.name())
-                        .stream()
-                        .count()
-                    == 0);
+            {
+              Stream<GenericResource> stream = armManagers
+                  .azureResourceManager()
+                  .genericResources()
+                  .listByResourceGroup(resourceGroup.name())
+                  .stream();
+              return stream
+                      .count()
+                  == 0;
+            });
   }
 
   private void assertHasVnetWithPurpose(String landingZoneId, SubnetResourcePurpose purpose) {

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/DeployedLandingZoneDefinitionProviderImplTest.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/DeployedLandingZoneDefinitionProviderImplTest.java
@@ -14,7 +14,7 @@ class DeployedLandingZoneDefinitionProviderImplTest {
 
   @BeforeEach
   void setUp() {
-    ArmManagers armManagers = new ArmManagers(null, null, null, null, null, null);
+    ArmManagers armManagers = new ArmManagers(null, null, null, null, null, null, null);
     provider = new LandingZoneDefinitionProviderImpl(armManagers);
   }
 

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/DeployedLandingZoneDefinitionProviderImplTest.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/DeployedLandingZoneDefinitionProviderImplTest.java
@@ -14,7 +14,7 @@ class DeployedLandingZoneDefinitionProviderImplTest {
 
   @BeforeEach
   void setUp() {
-    ArmManagers armManagers = new ArmManagers(null, null, null, null);
+    ArmManagers armManagers = new ArmManagers(null, null, null, null, null, null);
     provider = new LandingZoneDefinitionProviderImpl(armManagers);
   }
 

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/management/ResourcesDeleteManagerTest.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/management/ResourcesDeleteManagerTest.java
@@ -9,6 +9,7 @@ import bio.terra.landingzone.library.landingzones.definition.DefinitionVersion;
 import bio.terra.landingzone.library.landingzones.definition.factories.CromwellBaseResourcesFactory;
 import bio.terra.landingzone.library.landingzones.deployment.DeployedResource;
 import bio.terra.landingzone.library.landingzones.deployment.DeployedSubnet;
+import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
 import bio.terra.landingzone.library.landingzones.deployment.SubnetResourcePurpose;
 import bio.terra.landingzone.library.landingzones.management.deleterules.AKSAgentPoolHasMoreThanOneNode;
 import bio.terra.landingzone.library.landingzones.management.deleterules.AzureRelayHasHybridConnections;
@@ -108,16 +109,15 @@ class ResourcesDeleteManagerTest extends LandingZoneTestFixture {
         LandingZoneTestFixture.armManagers
             .azureResourceManager()
             .storageAccounts()
-            .getById(
-                resources.stream()
-                    .filter(
-                        r ->
-                            r.resourceType()
-                                .equalsIgnoreCase(
-                                    AzureResourceTypeUtils.AZURE_STORAGE_ACCOUNT_TYPE))
-                    .findFirst()
-                    .orElseThrow()
-                    .resourceId());
+            .listByResourceGroup(resourceGroup.name())
+            .stream()
+            .filter(
+                s ->
+                    s.tags()
+                        .getOrDefault(LandingZoneTagKeys.LANDING_ZONE_ID.toString(), "")
+                        .equalsIgnoreCase(landingZoneId.toString()))
+            .findFirst()
+            .orElseThrow();
 
     azureRelay =
         LandingZoneTestFixture.armManagers

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/management/deleterules/BaseDependencyRuleFixture.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/management/deleterules/BaseDependencyRuleFixture.java
@@ -8,6 +8,8 @@ import bio.terra.landingzone.library.landingzones.management.ResourceToDelete;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.resourcemanager.AzureResourceManager;
 import com.azure.resourcemanager.batch.BatchManager;
+import com.azure.resourcemanager.loganalytics.LogAnalyticsManager;
+import com.azure.resourcemanager.monitor.MonitorManager;
 import com.azure.resourcemanager.postgresql.PostgreSqlManager;
 import com.azure.resourcemanager.relay.RelayManager;
 import com.azure.resourcemanager.resources.models.GenericResource;
@@ -30,6 +32,8 @@ public class BaseDependencyRuleFixture {
   @Mock protected AzureResourceManager azureResourceManager;
   @Mock protected PostgreSqlManager postgreSqlManager;
   @Mock protected RelayManager relayManager;
+  @Mock protected LogAnalyticsManager logAnalyticsManager;
+  @Mock protected MonitorManager monitorManager;
 
   @Mock protected ResourceToDelete resourceToDelete;
   @Mock protected GenericResource resource;
@@ -37,7 +41,13 @@ public class BaseDependencyRuleFixture {
   @BeforeEach
   void setUpArmManager() {
     armManagers =
-        new ArmManagers(azureResourceManager, relayManager, batchManager, postgreSqlManager);
+        new ArmManagers(
+            azureResourceManager,
+            relayManager,
+            batchManager,
+            postgreSqlManager,
+            logAnalyticsManager,
+            monitorManager);
   }
 
   protected void setUpResourceToDelete() {

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/management/deleterules/BaseDependencyRuleFixture.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/management/deleterules/BaseDependencyRuleFixture.java
@@ -7,6 +7,7 @@ import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.management.ResourceToDelete;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.resourcemanager.AzureResourceManager;
+import com.azure.resourcemanager.applicationinsights.ApplicationInsightsManager;
 import com.azure.resourcemanager.batch.BatchManager;
 import com.azure.resourcemanager.loganalytics.LogAnalyticsManager;
 import com.azure.resourcemanager.monitor.MonitorManager;
@@ -34,6 +35,7 @@ public class BaseDependencyRuleFixture {
   @Mock protected RelayManager relayManager;
   @Mock protected LogAnalyticsManager logAnalyticsManager;
   @Mock protected MonitorManager monitorManager;
+  @Mock protected ApplicationInsightsManager applicationInsightsManager;
 
   @Mock protected ResourceToDelete resourceToDelete;
   @Mock protected GenericResource resource;
@@ -47,7 +49,8 @@ public class BaseDependencyRuleFixture {
             batchManager,
             postgreSqlManager,
             logAnalyticsManager,
-            monitorManager);
+            monitorManager,
+            applicationInsightsManager);
   }
 
   protected void setUpResourceToDelete() {

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/management/deleterules/ResourceDependencyDeleteRuleTest.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/management/deleterules/ResourceDependencyDeleteRuleTest.java
@@ -1,6 +1,6 @@
 package bio.terra.landingzone.library.landingzones.management.deleterules;
 
-import static bio.terra.landingzone.library.landingzones.management.AzureResourceTypeUtils.AZURE_VM_TYPE;
+import static bio.terra.landingzone.library.landingzones.management.AzureResourceTypeUtils.AZURE_VNET_TYPE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
@@ -27,8 +27,8 @@ class ResourceDependencyDeleteRuleTest {
   void setUp() {
     when(dependencyDeleteRule.applyRule(any())).thenCallRealMethod();
     when(resourceToDelete.resource()).thenReturn(genericResource);
-    when(genericResource.type()).thenReturn(AZURE_VM_TYPE);
-    when(dependencyDeleteRule.getExpectedType()).thenReturn(AZURE_VM_TYPE);
+    when(genericResource.type()).thenReturn(AZURE_VNET_TYPE);
+    when(dependencyDeleteRule.getExpectedType()).thenReturn(AZURE_VNET_TYPE);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/management/deleterules/VmsAreAttachedToVnetTest.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/management/deleterules/VmsAreAttachedToVnetTest.java
@@ -1,6 +1,6 @@
 package bio.terra.landingzone.library.landingzones.management.deleterules;
 
-import static bio.terra.landingzone.library.landingzones.management.AzureResourceTypeUtils.AZURE_VM_TYPE;
+import static bio.terra.landingzone.library.landingzones.management.AzureResourceTypeUtils.AZURE_VNET_TYPE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
@@ -27,7 +27,7 @@ class VmsAreAttachedToVnetTest extends BaseDependencyRuleFixture {
 
   @Test
   void getExpectedType_returnsExpectedType() {
-    assertThat(rule.getExpectedType(), equalTo(AZURE_VM_TYPE));
+    assertThat(rule.getExpectedType(), equalTo(AZURE_VNET_TYPE));
   }
 
   @Test


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TOAZ-227

This PR adds the following to the CromwellBaseResourcesFactory:
* a log analytics workspace
* application insights connected to that workspace
* diagnostic settings for the storage account to turn on audit logging
* monitoring for AKS cluster

2 points of note:
1. the storage account was moved to a prerequisite because it must exist before adding diagnostic settings
2. switching on monitoring for AKS cluster automatically deploys a container insights solution which is untagged, thus the extra hoops when deleting a LZ