### PR TITLE
[TOAZ-261] Allow the client to set the landing zone id when starting the create job

### DIFF
--- a/service/src/main/java/bio/terra/landingzone/service/iam/LandingZoneSamService.java
+++ b/service/src/main/java/bio/terra/landingzone/service/iam/LandingZoneSamService.java
@@ -188,7 +188,6 @@ public class LandingZoneSamService {
   @Traced
   public List<UUID> listLandingZoneResourceIds(BearerToken bearerToken)
       throws InterruptedException {
-    List<UUID> userLandingZoneResourceIds = null;
     var resourceApi = samResourcesApi(bearerToken.getToken());
     try {
       var userLandingZones =
@@ -207,7 +206,7 @@ public class LandingZoneSamService {
               })
           .toList();
     } catch (ApiException apiException) {
-      throw SamExceptionFactory.create("Error getting landing ID's in Sam", apiException);
+      throw SamExceptionFactory.create("Error getting landing zone ID's in Sam", apiException);
     }
   }
 

--- a/service/src/main/java/bio/terra/landingzone/service/landingzone/azure/LandingZoneService.java
+++ b/service/src/main/java/bio/terra/landingzone/service/landingzone/azure/LandingZoneService.java
@@ -129,7 +129,7 @@ public class LandingZoneService {
 
     checkIfRequestedFactoryExists(azureLandingZoneRequest);
     String jobDescription = "Creating Azure Landing Zone. Definition=%s, Version=%s";
-    UUID landingZoneId = UUID.randomUUID();
+    UUID landingZoneId = azureLandingZoneRequest.landingZoneId().orElseGet(() -> UUID.randomUUID());
     final LandingZoneJobBuilder jobBuilder =
         azureLandingZoneJobService
             .newJob()

--- a/service/src/main/java/bio/terra/landingzone/service/landingzone/azure/model/LandingZoneRequest.java
+++ b/service/src/main/java/bio/terra/landingzone/service/landingzone/azure/model/LandingZoneRequest.java
@@ -2,11 +2,16 @@ package bio.terra.landingzone.service.landingzone.azure.model;
 
 import bio.terra.landingzone.common.exception.MissingRequiredFieldsException;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 
 public record LandingZoneRequest(
-    String definition, String version, Map<String, String> parameters, UUID billingProfileId) {
+    String definition,
+    String version,
+    Map<String, String> parameters,
+    UUID billingProfileId,
+    Optional<UUID> landingZoneId) {
 
   public static Builder builder() {
     return new Builder();
@@ -17,6 +22,7 @@ public record LandingZoneRequest(
     private String version;
     private Map<String, String> parameters;
     private UUID billingProfileId;
+    private UUID landingZoneId;
 
     public Builder definition(String definition) {
       this.definition = definition;
@@ -38,6 +44,11 @@ public record LandingZoneRequest(
       return this;
     }
 
+    public Builder landingZoneId(UUID landingZoneId) {
+      this.landingZoneId = landingZoneId;
+      return this;
+    }
+
     public LandingZoneRequest build() {
       if (StringUtils.isBlank(definition)) {
         throw new MissingRequiredFieldsException(
@@ -49,7 +60,8 @@ public record LandingZoneRequest(
             "Azure landing zone definition requires billing profile ID");
       }
 
-      return new LandingZoneRequest(definition, version, parameters, billingProfileId);
+      return new LandingZoneRequest(
+          definition, version, parameters, billingProfileId, Optional.ofNullable(landingZoneId));
     }
   }
 }


### PR DESCRIPTION
Checked the flight logic - no need to update anything else in library code.
Cleaned up test code while I'm there.