### PR TITLE
TOAZ-290: add configurable set of users to newly created landing-zone resources

### DIFF
--- a/service/src/main/java/bio/terra/landingzone/library/configuration/LandingZoneSamConfiguration.java
+++ b/service/src/main/java/bio/terra/landingzone/library/configuration/LandingZoneSamConfiguration.java
@@ -1,5 +1,6 @@
 package bio.terra.landingzone.library.configuration;
 
+import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
@@ -11,11 +12,25 @@ public class LandingZoneSamConfiguration {
   /** URL of the SAM instance */
   private String basePath;
 
+  /**
+   * List of emails which should be granted 'user' role on newly created landing-zone resources in
+   * Sam.
+   */
+  private List<String> landingZoneResourceUsers;
+
   public String getBasePath() {
     return basePath;
   }
 
   public void setBasePath(String basePath) {
     this.basePath = basePath;
+  }
+
+  public List<String> getLandingZoneResourceUsers() {
+    return landingZoneResourceUsers;
+  }
+
+  public void setLandingZoneResourceUsers(List<String> landingZoneResourceUsers) {
+    this.landingZoneResourceUsers = landingZoneResourceUsers;
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/service/iam/LandingZoneSamService.java
+++ b/service/src/main/java/bio/terra/landingzone/service/iam/LandingZoneSamService.java
@@ -134,9 +134,13 @@ public class LandingZoneSamService {
     var policies =
         Map.of(
             "owner",
-            new AccessPolicyMembershipV2()
-                .addMemberEmailsItem(userInfo.getUserEmail())
-                .addRolesItem(SamConstants.SamRole.OWNER));
+                new AccessPolicyMembershipV2()
+                    .addMemberEmailsItem(userInfo.getUserEmail())
+                    .addRolesItem(SamConstants.SamRole.OWNER),
+            "user",
+                new AccessPolicyMembershipV2()
+                    .memberEmails(samConfig.getLandingZoneResourceUsers())
+                    .addRolesItem(SamConstants.SamRole.USER));
     var landingZoneRequest =
         new CreateResourceRequestV2()
             .resourceId(landingZoneId.toString())

--- a/service/src/main/java/bio/terra/landingzone/service/iam/SamConstants.java
+++ b/service/src/main/java/bio/terra/landingzone/service/iam/SamConstants.java
@@ -11,6 +11,7 @@ public class SamConstants {
 
   public static class SamRole {
     public static final String OWNER = "owner";
+    public static final String USER = "user";
 
     private SamRole() {}
   }


### PR DESCRIPTION
See https://broadworkbench.atlassian.net/browse/TOAZ-290

Related PRs:
- WSM: https://github.com/DataBiosphere/terra-workspace-manager/pull/928
- terra-helmfile:

This adds list of configurable `landingZoneResourceUsers`, and sets each entry as a `user` on newly-created landing-zone resources in Sam.

Tested on a BEE by making a billing-project in Terra UI. The policies set on the landing-zone are correct:
<img width="1865" alt="image" src="https://user-images.githubusercontent.com/5368863/204870567-166a0118-9639-4eb9-a48e-9425d47ebfdd.png">
