### PR TITLE
[TOA-311] Quota API returns low-priority node count

### DIFF
--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/management/quotas/BatchQuotaReader.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/management/quotas/BatchQuotaReader.java
@@ -37,6 +37,7 @@ public class BatchQuotaReader implements ResourceQuotaReader {
     Map<String, Object> quotaInformation = new HashMap<>();
     quotaInformation.put(
         "activeJobAndJobScheduleQuota", batchAccount.activeJobAndJobScheduleQuota());
+    quotaInformation.put("lowPriorityCoreQuota", batchAccount.lowPriorityCoreQuota());
     quotaInformation.put("dedicatedCoreQuota", batchAccount.dedicatedCoreQuota());
     quotaInformation.put(
         "dedicatedCoreQuotaPerVMFamilyEnforced",

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/management/quotas/BatchQuotaReaderTest.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/management/quotas/BatchQuotaReaderTest.java
@@ -29,6 +29,7 @@ class BatchQuotaReaderTest {
   private static final int ACTIVE_JOB_SCHEDULE_QUOTA = 10;
   private static final Integer DEDICATED_CORE_QUOTA = 10;
 
+  private static final Integer LOW_PRI_CORE_QUOTA = 5;
   private final Integer POOL_QUOTA = 5;
 
   @Mock private BatchManager batchManager;
@@ -53,6 +54,7 @@ class BatchQuotaReaderTest {
     when(batchAccount.dedicatedCoreQuota()).thenReturn(DEDICATED_CORE_QUOTA);
     when(batchAccount.poolQuota()).thenReturn(POOL_QUOTA);
     when(batchAccount.id()).thenReturn(STUB_BATCH_ACCOUNT_ID);
+    when(batchAccount.lowPriorityCoreQuota()).thenReturn(LOW_PRI_CORE_QUOTA);
   }
 
   private void setUpDedicatedCoreQuotaPerFamily() throws JsonProcessingException {
@@ -78,6 +80,7 @@ class BatchQuotaReaderTest {
     assertThat(quota.resourceId(), equalTo(STUB_BATCH_ACCOUNT_ID));
     assertThat(quota.quota(), hasEntry("activeJobAndJobScheduleQuota", ACTIVE_JOB_SCHEDULE_QUOTA));
     assertThat(quota.quota(), hasEntry("dedicatedCoreQuota", DEDICATED_CORE_QUOTA));
+    assertThat(quota.quota(), hasEntry("lowPriorityCoreQuota", LOW_PRI_CORE_QUOTA));
     assertThat(quota.quota(), hasEntry("dedicatedCoreQuotaPerVMFamilyEnforced", true));
     assertThat(quota.quota(), hasEntry("poolQuota", POOL_QUOTA));
     Map<String, Object> quotaPerVmFamily =


### PR DESCRIPTION
Adds the low-pri node count to the return object of the quota api. 