### PR TITLE
[WOR-812] Include BP id in deleted landing zone result

### DIFF
--- a/service/src/main/java/bio/terra/landingzone/service/landingzone/azure/model/DeletedLandingZone.java
+++ b/service/src/main/java/bio/terra/landingzone/service/landingzone/azure/model/DeletedLandingZone.java
@@ -3,4 +3,5 @@ package bio.terra.landingzone.service.landingzone.azure.model;
 import java.util.List;
 import java.util.UUID;
 
-public record DeletedLandingZone(UUID landingZoneId, List<String> deleteResources) {}
+public record DeletedLandingZone(
+    UUID landingZoneId, List<String> deleteResources, UUID billingProfileId) {}

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/delete/DeleteLandingZoneResourcesStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/delete/DeleteLandingZoneResourcesStep.java
@@ -56,6 +56,7 @@ public class DeleteLandingZoneResourcesStep implements Step {
       DeletedLandingZone deletedLandingZone =
           deleteLandingZoneResources(
               landingZoneId,
+              landingZoneRecord.billingProfileId(),
               landingZoneManagerProvider.createLandingZoneManager(landingZoneTarget));
 
       persistResponse(context, deletedLandingZone);
@@ -87,10 +88,9 @@ public class DeleteLandingZoneResourcesStep implements Step {
   }
 
   private DeletedLandingZone deleteLandingZoneResources(
-      UUID landingZoneId, LandingZoneManager landingZoneManager)
+      UUID landingZoneId, UUID billingProfileId, LandingZoneManager landingZoneManager)
       throws LandingZoneRuleDeleteException {
     List<String> deletedResources = landingZoneManager.deleteResources(landingZoneId.toString());
-
-    return new DeletedLandingZone(landingZoneId, deletedResources);
+    return new DeletedLandingZone(landingZoneId, deletedResources, billingProfileId);
   }
 }


### PR DESCRIPTION
The access checks to get a completed job was checking for the bp id, which didn't exist on the result.