### PR TITLE
[WOR-799] Add ability to attach to existing azure resources

### DIFF
--- a/service/src/main/java/bio/terra/landingzone/common/utils/LandingZoneFlightBeanBag.java
+++ b/service/src/main/java/bio/terra/landingzone/common/utils/LandingZoneFlightBeanBag.java
@@ -3,6 +3,7 @@ package bio.terra.landingzone.common.utils;
 import bio.terra.landingzone.db.LandingZoneDao;
 import bio.terra.landingzone.library.LandingZoneManagerProvider;
 import bio.terra.landingzone.library.configuration.LandingZoneAzureConfiguration;
+import bio.terra.landingzone.library.configuration.LandingZoneTestingConfiguration;
 import bio.terra.landingzone.service.bpm.LandingZoneBillingProfileManagerService;
 import bio.terra.landingzone.service.iam.LandingZoneSamService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Component;
 public class LandingZoneFlightBeanBag {
   private final LandingZoneDao landingZoneDao;
   private final LandingZoneAzureConfiguration azureConfiguration;
+  private final LandingZoneTestingConfiguration testingConfiguration;
   private final LandingZoneManagerProvider landingZoneManagerProvider;
   private final LandingZoneSamService samService;
   private final LandingZoneBillingProfileManagerService bpmService;
@@ -22,12 +24,14 @@ public class LandingZoneFlightBeanBag {
   public LandingZoneFlightBeanBag(
       LandingZoneDao landingZoneDao,
       LandingZoneAzureConfiguration azureConfiguration,
+      LandingZoneTestingConfiguration testingConfiguration,
       LandingZoneManagerProvider landingZoneManagerProvider,
       LandingZoneSamService samService,
       LandingZoneBillingProfileManagerService bpmService,
       ObjectMapper objectMapper) {
     this.landingZoneDao = landingZoneDao;
     this.azureConfiguration = azureConfiguration;
+    this.testingConfiguration = testingConfiguration;
     this.landingZoneManagerProvider = landingZoneManagerProvider;
     this.samService = samService;
     this.bpmService = bpmService;
@@ -60,5 +64,9 @@ public class LandingZoneFlightBeanBag {
 
   public ObjectMapper getObjectMapper() {
     return objectMapper;
+  }
+
+  public LandingZoneTestingConfiguration getTestingConfiguration() {
+    return testingConfiguration;
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/library/configuration/LandingZoneTestingConfiguration.java
+++ b/service/src/main/java/bio/terra/landingzone/library/configuration/LandingZoneTestingConfiguration.java
@@ -1,0 +1,25 @@
+package bio.terra.landingzone.library.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties
+@ConfigurationProperties(prefix = "landingzone.testing")
+public class LandingZoneTestingConfiguration {
+
+  private boolean allowAttach;
+
+  /**
+   * Determines whether we allow the "attachment" of a Terra landing zone to pre-deployed Azure
+   * resources.
+   */
+  public boolean isAllowAttach() {
+    return allowAttach;
+  }
+
+  public void setAllowAttach(boolean allowAttach) {
+    this.allowAttach = allowAttach;
+  }
+}

--- a/service/src/main/java/bio/terra/landingzone/service/landingzone/azure/model/LandingZoneRequest.java
+++ b/service/src/main/java/bio/terra/landingzone/service/landingzone/azure/model/LandingZoneRequest.java
@@ -1,6 +1,7 @@
 package bio.terra.landingzone.service.landingzone.azure.model;
 
 import bio.terra.landingzone.common.exception.MissingRequiredFieldsException;
+import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -63,5 +64,14 @@ public record LandingZoneRequest(
       return new LandingZoneRequest(
           definition, version, parameters, billingProfileId, Optional.ofNullable(landingZoneId));
     }
+  }
+
+  public boolean isAttaching() {
+    if (null == this.parameters) {
+      return false;
+    }
+
+    return Boolean.parseBoolean(
+        this.parameters().getOrDefault(LandingZoneFlightMapKeys.ATTACH, "false"));
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/LandingZoneFlightMapKeys.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/LandingZoneFlightMapKeys.java
@@ -6,8 +6,8 @@ public class LandingZoneFlightMapKeys {
   public static final String LANDING_ZONE_CREATE_PARAMS = "landingZoneCreateParams";
   public static final String BEARER_TOKEN = "bearerToken";
   public static final String BILLING_PROFILE = "billingProfile";
-
   public static final String RESOURCE_GROUP_TAGS = "rgTags";
+  public static final String ATTACH = "attach";
 
   private LandingZoneFlightMapKeys() {}
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneFlight.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneFlight.java
@@ -2,6 +2,8 @@ package bio.terra.landingzone.stairway.flight.create;
 
 import bio.terra.landingzone.common.utils.LandingZoneFlightBeanBag;
 import bio.terra.landingzone.common.utils.RetryRules;
+import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneRequest;
+import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.RetryRule;
@@ -26,10 +28,17 @@ public class CreateLandingZoneFlight extends Flight {
     final LandingZoneFlightBeanBag flightBeanBag =
         LandingZoneFlightBeanBag.getFromObject(applicationContext);
 
-    addCreateSteps(flightBeanBag);
+    addCreateSteps(flightBeanBag, inputParameters);
   }
 
-  private void addCreateSteps(LandingZoneFlightBeanBag flightBeanBag) {
+  private void addCreateSteps(LandingZoneFlightBeanBag flightBeanBag, FlightMap inputParameters) {
+    var requestedLandingZone =
+        inputParameters.get(
+            LandingZoneFlightMapKeys.LANDING_ZONE_CREATE_PARAMS, LandingZoneRequest.class);
+    if (requestedLandingZone == null) {
+      throw new RuntimeException("Unable to find input map");
+    }
+
     addStep(
         new CreateSamResourceStep(flightBeanBag.getSamService()), RetryRules.shortExponential());
 
@@ -41,10 +50,11 @@ public class CreateLandingZoneFlight extends Flight {
             flightBeanBag.getAzureLandingZoneManagerProvider(), flightBeanBag.getObjectMapper()),
         RetryRules.shortExponential());
 
-    addStep(
-        new CreateAzureLandingZoneStep(flightBeanBag.getAzureLandingZoneManagerProvider()),
-        RetryRules.cloud());
-
+    if (!requestedLandingZone.isAttaching()) {
+      addStep(
+          new CreateAzureLandingZoneStep(flightBeanBag.getAzureLandingZoneManagerProvider()),
+          RetryRules.cloud());
+    }
     addStep(
         new ResetResourceGroupTagsStep(
             flightBeanBag.getAzureLandingZoneManagerProvider(), flightBeanBag.getObjectMapper()),

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneFlight.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneFlight.java
@@ -4,6 +4,7 @@ import bio.terra.landingzone.common.utils.LandingZoneFlightBeanBag;
 import bio.terra.landingzone.common.utils.RetryRules;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneRequest;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.exception.LandingZoneCreateException;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.RetryRule;
@@ -36,7 +37,7 @@ public class CreateLandingZoneFlight extends Flight {
         inputParameters.get(
             LandingZoneFlightMapKeys.LANDING_ZONE_CREATE_PARAMS, LandingZoneRequest.class);
     if (requestedLandingZone == null) {
-      throw new RuntimeException("Unable to find input map");
+      throw new LandingZoneCreateException("Unable to find requested landing zone in input map");
     }
 
     addStep(


### PR DESCRIPTION
[Related ticket](https://broadworkbench.atlassian.net/browse/WOR-799) and [related design doc.](https://broadworkbench.atlassian.net/wiki/spaces/WOR/pages/2674950157/Azure+Test+Automation)

## Context
We need a way to create a landing zone for a limited set of critical path E2E tests (think: create workspace, delete workspace, etc.). To do so, we'll need a landing zone, but do not want to wait the ~10 minutes to spin up a "real" landing zone. In a testing configuration, the ability to "attach" to pre-deployed landing zone resources should suffice.

## Changes
* Adds a parameter to the creation job, `attach`. When present (and the LZ service configuration allows it), this will skip the creation of landing zone resources in the MRG. The flight still goes through the steps of checking the billing profile permissions and creating a Sam resource. 
* Adds a configuration `LandingZoneTestingConfiguration`. This controls whether the LZS allows the attachment functionality. I expect this will be off everywhere except for BEEs in a testing context. 

## TODO
* There is a follow-on task mentioned in the ticket to add verification that the expected resources are indeed present in the LZ when attaching. I've excluded that as part of this PR and expect it should be implemented as a follow-on -- I want to get people's 👀 on this first cut before investing the time needed for such verification.