### PR TITLE
[WOR-843] Allow Sam resource conflicts when re-using LZs during testi…

### DIFF
--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneFlight.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneFlight.java
@@ -41,7 +41,9 @@ public class CreateLandingZoneFlight extends Flight {
     }
 
     addStep(
-        new CreateSamResourceStep(flightBeanBag.getSamService()), RetryRules.shortExponential());
+        new CreateSamResourceStep(
+            flightBeanBag.getSamService(), requestedLandingZone.isAttaching()),
+        RetryRules.shortExponential());
 
     addStep(
         new GetBillingProfileStep(flightBeanBag.getBpmService()), RetryRules.shortExponential());

--- a/service/src/test/java/bio/terra/landingzone/service/iam/LandingZoneSamServiceTest.java
+++ b/service/src/test/java/bio/terra/landingzone/service/iam/LandingZoneSamServiceTest.java
@@ -167,7 +167,8 @@ class LandingZoneSamServiceTest {
     when(samClient.usersApi(anyString())).thenReturn(usersApi);
     samService = new LandingZoneSamService(samClient);
     // Test
-    samService.createLandingZone(SAM_USER.getBearerToken(), BILLING_PROFILE_ID, LANDING_ZONE_ID);
+    samService.createLandingZone(
+        SAM_USER.getBearerToken(), BILLING_PROFILE_ID, LANDING_ZONE_ID, false);
     // Verify
     verifyCreateResourceV2(policies);
   }
@@ -188,9 +189,30 @@ class LandingZoneSamServiceTest {
     when(samClient.usersApi(anyString())).thenReturn(usersApi);
     samService = new LandingZoneSamService(samClient);
     // Test
-    samService.createLandingZone(SAM_USER.getBearerToken(), BILLING_PROFILE_ID, LANDING_ZONE_ID);
+    samService.createLandingZone(
+        SAM_USER.getBearerToken(), BILLING_PROFILE_ID, LANDING_ZONE_ID, false);
     // Verify
     verifyCreateResourceV2(policies);
+  }
+
+  @Test
+  void createLandingZone_allowsConflictWhenAttaching() throws ApiException, InterruptedException {
+    var listOfUsers = List.of(SAM_USER.getEmail());
+
+    // Setup Mocks
+    setupSamUserInfoMock(true);
+    doThrow(new ApiException(HttpStatus.SC_CONFLICT, "already exists"))
+        .when(resourcesApi)
+        .createResourceV2(
+            eq(SamConstants.SamResourceType.LANDING_ZONE), any(CreateResourceRequestV2.class));
+    when(samClient.getLandingZoneResourceUsers()).thenReturn(listOfUsers);
+    when(samClient.resourcesApi(anyString())).thenReturn(resourcesApi);
+    when(samClient.usersApi(anyString())).thenReturn(usersApi);
+    samService = new LandingZoneSamService(samClient);
+
+    // Test
+    samService.createLandingZone(
+        SAM_USER.getBearerToken(), BILLING_PROFILE_ID, LANDING_ZONE_ID, true);
   }
 
   @Test
@@ -210,7 +232,7 @@ class LandingZoneSamServiceTest {
     // Test
     Assertions.assertThrows(
         SamInternalServerErrorException.class,
-        () -> samService.createLandingZone(token, BILLING_PROFILE_ID, LANDING_ZONE_ID));
+        () -> samService.createLandingZone(token, BILLING_PROFILE_ID, LANDING_ZONE_ID, false));
   }
 
   @Test


### PR DESCRIPTION
This modifies the LZ service to further support Azure e2e automated testing. 
* Allows Sam resource conflicts when attaching a Landing Zone. The premise is that previous test runs will utilize the same LZ ID and we want to avoid Sam resource conflicts on creation. Deleting the resource will still leave the ID unusable as `reuseIds` is set to [false](https://github.com/broadinstitute/sam/blob/develop/src/main/resources/reference.conf#L1327) on LZs (correctly). 
* Prevents the deletion of Azure resources if a landing zone was attached
* Prevents the deletion of the Sam resource if the create sam resource flight is being "undone" and the LZ was previously attached. 