### PR TITLE
[WOR-861] Do not fail deletion if backing MRG is inaccessible

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -95,13 +95,13 @@ jobs:
       - name: Test Service and Library with coverage
         run: ./gradlew --build-cache service:test --scan
 
-      - name: Testhaness Tests with coverage
+      - name: Test Harness Tests with coverage
         run: ./gradlew --build-cache testharness:test --scan
 
       - name: Integration Test with coverage
         run: ./gradlew --build-cache service:integration --scan
 
-      - name: Upload Testharness Test Reports
+      - name: Upload Test Harness Test Reports
         uses: actions/upload-artifact@v1
         if: always()
         with:

--- a/service/src/main/java/bio/terra/landingzone/service/landingzone/azure/model/DeletedLandingZone.java
+++ b/service/src/main/java/bio/terra/landingzone/service/landingzone/azure/model/DeletedLandingZone.java
@@ -1,7 +1,13 @@
 package bio.terra.landingzone.service.landingzone.azure.model;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
 public record DeletedLandingZone(
-    UUID landingZoneId, List<String> deleteResources, UUID billingProfileId) {}
+    UUID landingZoneId, List<String> deleteResources, UUID billingProfileId) {
+
+  public static DeletedLandingZone emptyLandingZone(UUID landingZoneId, UUID billingProfileId) {
+    return new DeletedLandingZone(landingZoneId, Collections.emptyList(), billingProfileId);
+  }
+}


### PR DESCRIPTION
## Context
If the MRG backing a landing zone is removed, deleting the landing zone results in an exception when the deletion code goes to pull in the resources for the landing zone. 

## This PR
* Handles the `AuthorizationFailed` error from Azure and allows deletion to proceed. Azure gives this error back when the MRG is deleted rather than a 404-type error. Given that the IAM on the MRG is not alterable by users due to deny assignments, we can assume that the MRG has been removed and can proceed forward with deletion. 
