### PR TITLE
[WOR-894] Add dependabot config for LZS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Enable version updates for Gradle
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "main"
+    reviewers:
+      - "@DataBiosphere/broadworkspaces"
+    labels:
+      - "dependency"
+      - "gradle"
+    commit-message:
+      prefix: "[No Ticket]"
+    ignore:
+      - dependency-name: "org.springframework.boot:spring-boot-gradle-plugin"
+        update-types: ["version-update:semver-major"]
+


### PR DESCRIPTION
Dependabot should scan for upgraded libs so we get the latest security updates. 