### PR TITLE
[WOR-904] Handle 409 when creating fixture batch pool in IT

### DIFF
--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/management/ResourcesDeleteManagerTest.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/management/ResourcesDeleteManagerTest.java
@@ -17,6 +17,7 @@ import bio.terra.landingzone.library.landingzones.management.deleterules.Landing
 import bio.terra.landingzone.library.landingzones.management.deleterules.PostgreSQLServerHasDBs;
 import bio.terra.landingzone.library.landingzones.management.deleterules.StorageAccountHasContainers;
 import bio.terra.landingzone.library.landingzones.management.deleterules.VmsAreAttachedToVnet;
+import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.batch.models.AutoScaleSettings;
 import com.azure.resourcemanager.batch.models.BatchAccount;
 import com.azure.resourcemanager.batch.models.DeploymentConfiguration;
@@ -253,30 +254,37 @@ class ResourcesDeleteManagerTest extends LandingZoneTestFixture {
   }
 
   private void createBatchPool(String poolName) {
-    var pool =
-        armManagers
-            .batchManager()
-            .pools()
-            .define(poolName)
-            .withExistingBatchAccount(resourceGroup.name(), batch.name())
-            .withVmSize("Standard_D2as_v4")
-            .withDeploymentConfiguration(
-                new DeploymentConfiguration()
-                    .withVirtualMachineConfiguration(
-                        new VirtualMachineConfiguration()
-                            .withImageReference(
-                                new ImageReference()
-                                    .withPublisher("Canonical")
-                                    .withOffer("UbuntuServer")
-                                    .withSku("18.04-LTS")
-                                    .withVersion("latest"))
-                            .withNodeAgentSkuId("batch.node.ubuntu 18.04")))
-            .withScaleSettings(
-                new ScaleSettings()
-                    .withAutoScale(
-                        new AutoScaleSettings()
-                            .withFormula("$TargetDedicatedNodes=1")
-                            .withEvaluationInterval(Duration.parse("PT5M"))))
-            .create();
+    try {
+      armManagers
+          .batchManager()
+          .pools()
+          .define(poolName)
+          .withExistingBatchAccount(resourceGroup.name(), batch.name())
+          .withVmSize("Standard_D2as_v4")
+          .withDeploymentConfiguration(
+              new DeploymentConfiguration()
+                  .withVirtualMachineConfiguration(
+                      new VirtualMachineConfiguration()
+                          .withImageReference(
+                              new ImageReference()
+                                  .withPublisher("Canonical")
+                                  .withOffer("UbuntuServer")
+                                  .withSku("18.04-LTS")
+                                  .withVersion("latest"))
+                          .withNodeAgentSkuId("batch.node.ubuntu 18.04")))
+          .withScaleSettings(
+              new ScaleSettings()
+                  .withAutoScale(
+                      new AutoScaleSettings()
+                          .withFormula("$TargetDedicatedNodes=1")
+                          .withEvaluationInterval(Duration.parse("PT5M"))))
+          .create();
+    } catch (ManagementException e) {
+      // check if there's already a batch pool in the rg -- if so, move on.
+      if (!e.getValue().getCode().equals("Conflict")) {
+
+        throw new RuntimeException(e);
+      }
+    }
   }
 }


### PR DESCRIPTION
This test fails often due to a resource conflict error as the client retries resource creation. I'm uncertain why it's retrying so often, but a 409 seems like a good indicator that we already have a useable batch pool for this test. 