### PR TITLE
[WOR-952] Exclude vulnerable version of json-smart

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -22,7 +22,10 @@ dependencies {
     implementation 'org.postgresql:postgresql:42.6.0'
     implementation 'javax.servlet:jstl:1.2'
     implementation group: 'com.azure', name: 'azure-core', version: '1.34.0'
-    implementation group: 'com.azure', name: 'azure-identity', version: '1.8.2'
+    implementation (group: 'com.azure', name: 'azure-identity', version: '1.8.2') {
+        exclude group: 'net.minidev', module: 'json-smart'
+    }
+    implementation group: 'net.minidev', 'name': 'json-smart', version: '2.4.10'
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-compute', version: '2.25.0'
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-containerinstance', version: '2.25.0'
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-msi', version: '2.25.0'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -23,6 +23,9 @@ dependencies {
     implementation 'javax.servlet:jstl:1.2'
     implementation group: 'com.azure', name: 'azure-core', version: '1.34.0'
     implementation (group: 'com.azure', name: 'azure-identity', version: '1.8.2') {
+        // the msal4j transitive dependency is still pulling in an old version of json-smart
+        // which is vulnerable to CVE-2023-1370
+        // see https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/611
         exclude group: 'net.minidev', module: 'json-smart'
     }
     implementation group: 'net.minidev', 'name': 'json-smart', version: '2.4.10'

--- a/testharness/build.gradle
+++ b/testharness/build.gradle
@@ -1,9 +1,12 @@
 plugins {
     id 'bio.terra.landingzone.java-spring-app-conventions'
 }
-
+dependencyLocking {
+    lockAllConfigurations()
+}
 dependencies {
     implementation project(":service")
+    implementation 'net.minidev:json-smart:2.4.10'
     implementation 'bio.terra:terra-common-lib'
     implementation 'org.apache.commons:commons-dbcp2'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'

--- a/testharness/build.gradle
+++ b/testharness/build.gradle
@@ -1,12 +1,15 @@
 plugins {
     id 'bio.terra.landingzone.java-spring-app-conventions'
 }
-dependencyLocking {
-    lockAllConfigurations()
-}
+
 dependencies {
     implementation project(":service")
-    implementation 'net.minidev:json-smart:2.4.10'
+
+    constraints {
+        implementation 'net.minidev:json-smart:2.4.10'
+    }
+    implementation 'net.minidev:json-smart'
+
     implementation 'bio.terra:terra-common-lib'
     implementation 'org.apache.commons:commons-dbcp2'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'

--- a/testharness/build.gradle
+++ b/testharness/build.gradle
@@ -3,12 +3,10 @@ plugins {
 }
 
 dependencies {
-    implementation project(":service")
-
-    constraints {
-        implementation 'net.minidev:json-smart:2.4.10'
+    implementation (project(":service")) {
+        exclude group: 'net.minidev', module: 'json-smart'
     }
-    implementation 'net.minidev:json-smart'
+    implementation 'net.minidev:json-smart:2.4.10'
 
     implementation 'bio.terra:terra-common-lib'
     implementation 'org.apache.commons:commons-dbcp2'
@@ -24,7 +22,9 @@ dependencies {
 
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'com.vaadin.external.google', module: 'android-json'
+        exclude group: 'net.minidev', module: 'json-smart'
     }
+
     testImplementation group: "org.hamcrest", name: "hamcrest", version: "2.2"
 
     // Allows us to mock final classes

--- a/testharness/build.gradle
+++ b/testharness/build.gradle
@@ -4,6 +4,9 @@ plugins {
 
 dependencies {
     implementation (project(":service")) {
+        // the msal4j transitive dependency is still pulling in an old version of json-smart
+        // which is vulnerable to CVE-2023-1370
+        // see https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/611
         exclude group: 'net.minidev', module: 'json-smart'
     }
     implementation 'net.minidev:json-smart:2.4.10'
@@ -24,7 +27,6 @@ dependencies {
         exclude group: 'com.vaadin.external.google', module: 'android-json'
         exclude group: 'net.minidev', module: 'json-smart'
     }
-
     testImplementation group: "org.hamcrest", name: "hamcrest", version: "2.2"
 
     // Allows us to mock final classes


### PR DESCRIPTION
json-smart 2.4.8 is still pinging the sourceclear scans for this library even after upgrading to the latest azure-identity. This is likely because an upstream dep of azure-identity is still pulling in 2.4.8 transitively even though azure-identity has upgraded itself. I'm explicitly excluding the dep in both `service` and `testharness` and pulling in 2.4.10. It looks like the next azure-sdk should fix this issue so we should look into removing this workaround once that is released in May. 