### PR TITLE
WOR-941 Deploy sentinel to protected data LZ log analytics workspace in customer MRG

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-monitor', version: '2.26.0'
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-applicationinsights', version: '1.0.0-beta.5'
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager', version: '2.26.0'
+    implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-securityinsights', version: '1.0.0-beta.4'
 
     liquibaseRuntime 'org.liquibase:liquibase-core:4.21.1'
     liquibaseRuntime 'info.picocli:picocli:4.7.3'

--- a/service/src/main/java/bio/terra/landingzone/common/utils/LandingZoneFlightBeanBag.java
+++ b/service/src/main/java/bio/terra/landingzone/common/utils/LandingZoneFlightBeanBag.java
@@ -3,6 +3,7 @@ package bio.terra.landingzone.common.utils;
 import bio.terra.landingzone.db.LandingZoneDao;
 import bio.terra.landingzone.library.LandingZoneManagerProvider;
 import bio.terra.landingzone.library.configuration.LandingZoneAzureConfiguration;
+import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfiguration;
 import bio.terra.landingzone.library.configuration.LandingZoneTestingConfiguration;
 import bio.terra.landingzone.service.bpm.LandingZoneBillingProfileManagerService;
 import bio.terra.landingzone.service.iam.LandingZoneSamService;
@@ -22,6 +23,7 @@ public class LandingZoneFlightBeanBag {
   private final LandingZoneSamService samService;
   private final LandingZoneBillingProfileManagerService bpmService;
   private final ObjectMapper objectMapper;
+  private final LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration;
 
   @Lazy
   @Autowired
@@ -33,6 +35,7 @@ public class LandingZoneFlightBeanBag {
       LandingZoneManagerProvider landingZoneManagerProvider,
       LandingZoneSamService samService,
       LandingZoneBillingProfileManagerService bpmService,
+      LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration,
       ObjectMapper objectMapper) {
     this.landingZoneService = landingZoneService;
     this.landingZoneDao = landingZoneDao;
@@ -41,6 +44,7 @@ public class LandingZoneFlightBeanBag {
     this.landingZoneManagerProvider = landingZoneManagerProvider;
     this.samService = samService;
     this.bpmService = bpmService;
+    this.landingZoneProtectedDataConfiguration = landingZoneProtectedDataConfiguration;
     this.objectMapper = objectMapper;
   }
 
@@ -78,5 +82,9 @@ public class LandingZoneFlightBeanBag {
 
   public LandingZoneTestingConfiguration getTestingConfiguration() {
     return testingConfiguration;
+  }
+
+  public LandingZoneProtectedDataConfiguration getLandingZoneProtectedDataConfiguration() {
+    return landingZoneProtectedDataConfiguration;
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/library/configuration/LandingZoneProtectedDataConfiguration.java
+++ b/service/src/main/java/bio/terra/landingzone/library/configuration/LandingZoneProtectedDataConfiguration.java
@@ -1,0 +1,29 @@
+package bio.terra.landingzone.library.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties
+@ConfigurationProperties(prefix = "landingzone.protected-data")
+public class LandingZoneProtectedDataConfiguration {
+  private String logicAppResourceId;
+  private String tenantId;
+
+  public String getLogicAppResourceId() {
+    return logicAppResourceId;
+  }
+
+  public void setLogicAppResourceId(String logicAppResourceId) {
+    this.logicAppResourceId = logicAppResourceId;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(String tenantId) {
+    this.tenantId = tenantId;
+  }
+}

--- a/service/src/main/java/bio/terra/landingzone/library/configuration/LandingZoneProtectedDataConfiguration.java
+++ b/service/src/main/java/bio/terra/landingzone/library/configuration/LandingZoneProtectedDataConfiguration.java
@@ -7,10 +7,21 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @EnableConfigurationProperties
 @ConfigurationProperties(prefix = "landingzone.protected-data")
+/**
+ * This represents configuration for "ProtectedData" Landing Zone. We are creating Automation rule
+ * in Sentinel. This automation rule should trigger a certain "playbook".The "playbook" is
+ * represented by an Azure LogicApp service. To refer to a certain LogicApp it is required to pass
+ * LogicApp identifier and tenant where it resides.
+ */
 public class LandingZoneProtectedDataConfiguration {
   private String logicAppResourceId;
   private String tenantId;
 
+  /**
+   * Returns resource identifier of an Azure LogicApp.
+   *
+   * @return Azure resource identifier.
+   */
   public String getLogicAppResourceId() {
     return logicAppResourceId;
   }
@@ -19,6 +30,11 @@ public class LandingZoneProtectedDataConfiguration {
     this.logicAppResourceId = logicAppResourceId;
   }
 
+  /**
+   * Returns tenant identifier where LogicApp resides.
+   *
+   * @return Azure tenant identifier.
+   */
   public String getTenantId() {
     return tenantId;
   }

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/ArmManagers.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/ArmManagers.java
@@ -7,6 +7,7 @@ import com.azure.resourcemanager.loganalytics.LogAnalyticsManager;
 import com.azure.resourcemanager.monitor.MonitorManager;
 import com.azure.resourcemanager.postgresql.PostgreSqlManager;
 import com.azure.resourcemanager.relay.RelayManager;
+import com.azure.resourcemanager.securityinsights.SecurityInsightsManager;
 
 /** Record with the ARM clients required for deployments */
 public record ArmManagers(
@@ -16,4 +17,5 @@ public record ArmManagers(
     PostgreSqlManager postgreSqlManager,
     LogAnalyticsManager logAnalyticsManager,
     MonitorManager monitorManager,
-    ApplicationInsightsManager applicationInsightsManager) {}
+    ApplicationInsightsManager applicationInsightsManager,
+    SecurityInsightsManager securityInsightsManager) {}

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/management/LandingZoneManager.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/management/LandingZoneManager.java
@@ -28,6 +28,7 @@ import com.azure.resourcemanager.postgresql.PostgreSqlManager;
 import com.azure.resourcemanager.relay.RelayManager;
 import com.azure.resourcemanager.resources.fluentcore.arm.models.HasId;
 import com.azure.resourcemanager.resources.models.ResourceGroup;
+import com.azure.resourcemanager.securityinsights.SecurityInsightsManager;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -100,6 +101,8 @@ public class LandingZoneManager {
     MonitorManager monitorManager = MonitorManager.authenticate(credential, profile);
     ApplicationInsightsManager applicationInsightsManager =
         ApplicationInsightsManager.authenticate(credential, profile);
+    SecurityInsightsManager securityInsightsManager =
+        SecurityInsightsManager.authenticate(credential, profile);
 
     return new ArmManagers(
         azureResourceManager,
@@ -108,7 +111,8 @@ public class LandingZoneManager {
         postgreSqlManager,
         logAnalyticsManager,
         monitorManager,
-        applicationInsightsManager);
+        applicationInsightsManager,
+        securityInsightsManager);
   }
 
   public static List<FactoryDefinitionInfo> listDefinitionFactories() {

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/CromwellStepsDefinitionProvider.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/CromwellStepsDefinitionProvider.java
@@ -5,7 +5,19 @@ import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfi
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
+import bio.terra.landingzone.stairway.flight.create.resource.step.CreateAksStep;
+import bio.terra.landingzone.stairway.flight.create.resource.step.CreateAppInsightsStep;
+import bio.terra.landingzone.stairway.flight.create.resource.step.CreateBatchAccountStep;
+import bio.terra.landingzone.stairway.flight.create.resource.step.CreateBatchLogSettingsStep;
+import bio.terra.landingzone.stairway.flight.create.resource.step.CreateLogAnalyticsDataCollectionRulesStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateLogAnalyticsWorkspaceStep;
+import bio.terra.landingzone.stairway.flight.create.resource.step.CreatePostgresLogSettingsStep;
+import bio.terra.landingzone.stairway.flight.create.resource.step.CreatePostgresqlDbStep;
+import bio.terra.landingzone.stairway.flight.create.resource.step.CreatePrivateEndpointStep;
+import bio.terra.landingzone.stairway.flight.create.resource.step.CreateRelayNamespaceStep;
+import bio.terra.landingzone.stairway.flight.create.resource.step.CreateStorageAccountCorsRules;
+import bio.terra.landingzone.stairway.flight.create.resource.step.CreateStorageAccountStep;
+import bio.terra.landingzone.stairway.flight.create.resource.step.CreateStorageAuditLogSettingsStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateVnetStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.GetManagedResourceGroupInfo;
 import bio.terra.stairway.RetryRule;
@@ -47,54 +59,46 @@ public class CromwellStepsDefinitionProvider implements StepsDefinitionProvider 
         Pair.of(
             new CreateLogAnalyticsWorkspaceStep(
                 armManagers, parametersResolver, resourceNameGenerator),
-            RetryRules.cloud()) // ,
-        //        Pair.of(
-        //            new CreatePostgresqlDbStep(armManagers, parametersResolver,
-        // resourceNameGenerator),
-        //            RetryRules.cloud()),
-        //        Pair.of(
-        //            new CreateStorageAccountStep(armManagers, parametersResolver,
-        // resourceNameGenerator),
-        //            RetryRules.cloud()),
-        //        Pair.of(
-        //            new CreateBatchAccountStep(armManagers, parametersResolver,
-        // resourceNameGenerator),
-        //            RetryRules.cloud()),
-        //        Pair.of(
-        //            new CreateStorageAccountCorsRules(
-        //                armManagers, parametersResolver, resourceNameGenerator),
-        //            RetryRules.cloud()),
-        //        Pair.of(
-        //            new CreateLogAnalyticsDataCollectionRulesStep(
-        //                armManagers, parametersResolver, resourceNameGenerator),
-        //            RetryRules.cloud()),
-        //        Pair.of(
-        //            new CreatePrivateEndpointStep(armManagers, parametersResolver,
-        // resourceNameGenerator),
-        //            RetryRules.cloud()),
-        //        Pair.of(
-        //            new CreateAksStep(armManagers, parametersResolver, resourceNameGenerator),
-        //            RetryRules.cloud()),
-        //        Pair.of(
-        //            new CreateRelayNamespaceStep(armManagers, parametersResolver,
-        // resourceNameGenerator),
-        //            RetryRules.cloud()),
-        //        Pair.of(
-        //            new CreateStorageAuditLogSettingsStep(
-        //                armManagers, parametersResolver, resourceNameGenerator),
-        //            RetryRules.cloud()),
-        //        Pair.of(
-        //            new CreateBatchLogSettingsStep(armManagers, parametersResolver,
-        // resourceNameGenerator),
-        //            RetryRules.cloud()),
-        //        Pair.of(
-        //            new CreatePostgresLogSettingsStep(
-        //                armManagers, parametersResolver, resourceNameGenerator),
-        //            RetryRules.cloud()),
-        //        Pair.of(
-        //            new CreateAppInsightsStep(armManagers, parametersResolver,
-        // resourceNameGenerator),
-        //            RetryRules.cloud())
-        );
+            RetryRules.cloud()),
+        Pair.of(
+            new CreatePostgresqlDbStep(armManagers, parametersResolver, resourceNameGenerator),
+            RetryRules.cloud()),
+        Pair.of(
+            new CreateStorageAccountStep(armManagers, parametersResolver, resourceNameGenerator),
+            RetryRules.cloud()),
+        Pair.of(
+            new CreateBatchAccountStep(armManagers, parametersResolver, resourceNameGenerator),
+            RetryRules.cloud()),
+        Pair.of(
+            new CreateStorageAccountCorsRules(
+                armManagers, parametersResolver, resourceNameGenerator),
+            RetryRules.cloud()),
+        Pair.of(
+            new CreateLogAnalyticsDataCollectionRulesStep(
+                armManagers, parametersResolver, resourceNameGenerator),
+            RetryRules.cloud()),
+        Pair.of(
+            new CreatePrivateEndpointStep(armManagers, parametersResolver, resourceNameGenerator),
+            RetryRules.cloud()),
+        Pair.of(
+            new CreateAksStep(armManagers, parametersResolver, resourceNameGenerator),
+            RetryRules.cloud()),
+        Pair.of(
+            new CreateRelayNamespaceStep(armManagers, parametersResolver, resourceNameGenerator),
+            RetryRules.cloud()),
+        Pair.of(
+            new CreateStorageAuditLogSettingsStep(
+                armManagers, parametersResolver, resourceNameGenerator),
+            RetryRules.cloud()),
+        Pair.of(
+            new CreateBatchLogSettingsStep(armManagers, parametersResolver, resourceNameGenerator),
+            RetryRules.cloud()),
+        Pair.of(
+            new CreatePostgresLogSettingsStep(
+                armManagers, parametersResolver, resourceNameGenerator),
+            RetryRules.cloud()),
+        Pair.of(
+            new CreateAppInsightsStep(armManagers, parametersResolver, resourceNameGenerator),
+            RetryRules.cloud()));
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/CromwellStepsDefinitionProvider.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/CromwellStepsDefinitionProvider.java
@@ -1,23 +1,11 @@
 package bio.terra.landingzone.stairway.flight;
 
 import bio.terra.landingzone.common.utils.RetryRules;
+import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfiguration;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
-import bio.terra.landingzone.stairway.flight.create.resource.step.AggregateLandingZoneResourcesStep;
-import bio.terra.landingzone.stairway.flight.create.resource.step.CreateAksStep;
-import bio.terra.landingzone.stairway.flight.create.resource.step.CreateAppInsightsStep;
-import bio.terra.landingzone.stairway.flight.create.resource.step.CreateBatchAccountStep;
-import bio.terra.landingzone.stairway.flight.create.resource.step.CreateBatchLogSettingsStep;
-import bio.terra.landingzone.stairway.flight.create.resource.step.CreateLogAnalyticsDataCollectionRulesStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateLogAnalyticsWorkspaceStep;
-import bio.terra.landingzone.stairway.flight.create.resource.step.CreatePostgresLogSettingsStep;
-import bio.terra.landingzone.stairway.flight.create.resource.step.CreatePostgresqlDbStep;
-import bio.terra.landingzone.stairway.flight.create.resource.step.CreatePrivateEndpointStep;
-import bio.terra.landingzone.stairway.flight.create.resource.step.CreateRelayNamespaceStep;
-import bio.terra.landingzone.stairway.flight.create.resource.step.CreateStorageAccountCorsRules;
-import bio.terra.landingzone.stairway.flight.create.resource.step.CreateStorageAccountStep;
-import bio.terra.landingzone.stairway.flight.create.resource.step.CreateStorageAuditLogSettingsStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateVnetStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.GetManagedResourceGroupInfo;
 import bio.terra.stairway.RetryRule;
@@ -31,7 +19,8 @@ public class CromwellStepsDefinitionProvider implements StepsDefinitionProvider 
   public List<Pair<Step, RetryRule>> get(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator) {
+      ResourceNameGenerator resourceNameGenerator,
+      LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration) {
     /*
      * ~ - depends on
      * 1) VNet step
@@ -58,47 +47,54 @@ public class CromwellStepsDefinitionProvider implements StepsDefinitionProvider 
         Pair.of(
             new CreateLogAnalyticsWorkspaceStep(
                 armManagers, parametersResolver, resourceNameGenerator),
-            RetryRules.cloud()),
-        Pair.of(
-            new CreatePostgresqlDbStep(armManagers, parametersResolver, resourceNameGenerator),
-            RetryRules.cloud()),
-        Pair.of(
-            new CreateStorageAccountStep(armManagers, parametersResolver, resourceNameGenerator),
-            RetryRules.cloud()),
-        Pair.of(
-            new CreateBatchAccountStep(armManagers, parametersResolver, resourceNameGenerator),
-            RetryRules.cloud()),
-        Pair.of(
-            new CreateStorageAccountCorsRules(
-                armManagers, parametersResolver, resourceNameGenerator),
-            RetryRules.cloud()),
-        Pair.of(
-            new CreateLogAnalyticsDataCollectionRulesStep(
-                armManagers, parametersResolver, resourceNameGenerator),
-            RetryRules.cloud()),
-        Pair.of(
-            new CreatePrivateEndpointStep(armManagers, parametersResolver, resourceNameGenerator),
-            RetryRules.cloud()),
-        Pair.of(
-            new CreateAksStep(armManagers, parametersResolver, resourceNameGenerator),
-            RetryRules.cloud()),
-        Pair.of(
-            new CreateRelayNamespaceStep(armManagers, parametersResolver, resourceNameGenerator),
-            RetryRules.cloud()),
-        Pair.of(
-            new CreateStorageAuditLogSettingsStep(
-                armManagers, parametersResolver, resourceNameGenerator),
-            RetryRules.cloud()),
-        Pair.of(
-            new CreateBatchLogSettingsStep(armManagers, parametersResolver, resourceNameGenerator),
-            RetryRules.cloud()),
-        Pair.of(
-            new CreatePostgresLogSettingsStep(
-                armManagers, parametersResolver, resourceNameGenerator),
-            RetryRules.cloud()),
-        Pair.of(
-            new CreateAppInsightsStep(armManagers, parametersResolver, resourceNameGenerator),
-            RetryRules.cloud()),
-        Pair.of(new AggregateLandingZoneResourcesStep(), RetryRules.shortExponential()));
+            RetryRules.cloud()) // ,
+        //        Pair.of(
+        //            new CreatePostgresqlDbStep(armManagers, parametersResolver,
+        // resourceNameGenerator),
+        //            RetryRules.cloud()),
+        //        Pair.of(
+        //            new CreateStorageAccountStep(armManagers, parametersResolver,
+        // resourceNameGenerator),
+        //            RetryRules.cloud()),
+        //        Pair.of(
+        //            new CreateBatchAccountStep(armManagers, parametersResolver,
+        // resourceNameGenerator),
+        //            RetryRules.cloud()),
+        //        Pair.of(
+        //            new CreateStorageAccountCorsRules(
+        //                armManagers, parametersResolver, resourceNameGenerator),
+        //            RetryRules.cloud()),
+        //        Pair.of(
+        //            new CreateLogAnalyticsDataCollectionRulesStep(
+        //                armManagers, parametersResolver, resourceNameGenerator),
+        //            RetryRules.cloud()),
+        //        Pair.of(
+        //            new CreatePrivateEndpointStep(armManagers, parametersResolver,
+        // resourceNameGenerator),
+        //            RetryRules.cloud()),
+        //        Pair.of(
+        //            new CreateAksStep(armManagers, parametersResolver, resourceNameGenerator),
+        //            RetryRules.cloud()),
+        //        Pair.of(
+        //            new CreateRelayNamespaceStep(armManagers, parametersResolver,
+        // resourceNameGenerator),
+        //            RetryRules.cloud()),
+        //        Pair.of(
+        //            new CreateStorageAuditLogSettingsStep(
+        //                armManagers, parametersResolver, resourceNameGenerator),
+        //            RetryRules.cloud()),
+        //        Pair.of(
+        //            new CreateBatchLogSettingsStep(armManagers, parametersResolver,
+        // resourceNameGenerator),
+        //            RetryRules.cloud()),
+        //        Pair.of(
+        //            new CreatePostgresLogSettingsStep(
+        //                armManagers, parametersResolver, resourceNameGenerator),
+        //            RetryRules.cloud()),
+        //        Pair.of(
+        //            new CreateAppInsightsStep(armManagers, parametersResolver,
+        // resourceNameGenerator),
+        //            RetryRules.cloud())
+        );
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/ProtectedDataStepsDefinitionProvider.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/ProtectedDataStepsDefinitionProvider.java
@@ -1,10 +1,15 @@
 package bio.terra.landingzone.stairway.flight;
 
+import bio.terra.landingzone.common.utils.RetryRules;
+import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfiguration;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
+import bio.terra.landingzone.stairway.flight.create.resource.step.CreateSentinelRunPlaybookAutomationRule;
+import bio.terra.landingzone.stairway.flight.create.resource.step.CreateSentinelStep;
 import bio.terra.stairway.RetryRule;
 import bio.terra.stairway.Step;
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -13,11 +18,31 @@ public class ProtectedDataStepsDefinitionProvider extends CromwellStepsDefinitio
   public List<Pair<Step, RetryRule>> get(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator) {
-    var cromwellBaseSteps = super.get(armManagers, parametersResolver, resourceNameGenerator);
+      ResourceNameGenerator resourceNameGenerator,
+      LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration) {
+    // inherit all cromwell steps and define specific below
+    var protectedDataSteps =
+        new ArrayList<>(
+            super.get(
+                armManagers,
+                parametersResolver,
+                resourceNameGenerator,
+                landingZoneProtectedDataConfiguration));
 
-    // add steps specific to protected data
+    protectedDataSteps.add(
+        Pair.of(
+            new CreateSentinelStep(armManagers, parametersResolver, resourceNameGenerator),
+            RetryRules.cloud()));
 
-    return cromwellBaseSteps;
+    protectedDataSteps.add(
+        Pair.of(
+            new CreateSentinelRunPlaybookAutomationRule(
+                armManagers,
+                parametersResolver,
+                resourceNameGenerator,
+                landingZoneProtectedDataConfiguration),
+            RetryRules.cloud()));
+
+    return protectedDataSteps;
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/StepsDefinitionProvider.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/StepsDefinitionProvider.java
@@ -1,5 +1,6 @@
 package bio.terra.landingzone.stairway.flight;
 
+import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfiguration;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
@@ -19,10 +20,12 @@ public interface StepsDefinitionProvider {
    * @param ArmManagers armManagers
    * @param ParametersResolver parametersResolver
    * @param ResourceNameGenerator resourceNameGenerator
+   * @param LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration
    * @return List of pairs of steps and step's retry rule
    */
   List<Pair<Step, RetryRule>> get(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator);
+      ResourceNameGenerator resourceNameGenerator,
+      LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration);
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelRunPlaybookAutomationRule.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelRunPlaybookAutomationRule.java
@@ -35,13 +35,14 @@ public class CreateSentinelRunPlaybookAutomationRule extends BaseResourceCreateS
 
   @Override
   protected void createResource(FlightContext context, ArmManagers armManagers) {
-    var workspace =
+    var logAnalyticsWorkspace =
         getParameterOrThrow(
             context.getWorkingMap(),
             CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_RESOURCE_KEY,
             LandingZoneResource.class);
 
-    if (workspace.resourceName().isEmpty()) {
+    var logAnalyticsWorkspaceResourceName = logAnalyticsWorkspace.resourceName();
+    if (logAnalyticsWorkspaceResourceName.isEmpty()) {
       throw new MissingRequiredFieldsException("LogAnalyticsWorkspace resource name is not set.");
     }
 
@@ -64,7 +65,7 @@ public class CreateSentinelRunPlaybookAutomationRule extends BaseResourceCreateS
             .securityInsightsManager()
             .automationRules()
             .define("runSendSlackNotificationPlaybook")
-            .withExistingWorkspace(getMRGName(context), workspace.resourceName().get())
+            .withExistingWorkspace(getMRGName(context), logAnalyticsWorkspaceResourceName.get())
             .withDisplayName("Run Slack Notification Playbook")
             .withOrder(1)
             .withTriggeringLogic(trigger)

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelRunPlaybookAutomationRule.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelRunPlaybookAutomationRule.java
@@ -5,6 +5,7 @@ import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
+import bio.terra.landingzone.stairway.flight.exception.MissingRequiredFieldsException;
 import bio.terra.stairway.FlightContext;
 import com.azure.resourcemanager.securityinsights.models.AutomationRuleRunPlaybookAction;
 import com.azure.resourcemanager.securityinsights.models.AutomationRuleTriggeringLogic;
@@ -39,6 +40,10 @@ public class CreateSentinelRunPlaybookAutomationRule extends BaseResourceCreateS
             context.getWorkingMap(),
             CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_RESOURCE_KEY,
             LandingZoneResource.class);
+
+    if (workspace.resourceName().isEmpty()) {
+      throw new MissingRequiredFieldsException("LogAnalyticsWorkspace resource name is not set.");
+    }
 
     var trigger =
         new AutomationRuleTriggeringLogic()

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelRunPlaybookAutomationRule.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelRunPlaybookAutomationRule.java
@@ -1,0 +1,85 @@
+package bio.terra.landingzone.stairway.flight.create.resource.step;
+
+import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfiguration;
+import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
+import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
+import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
+import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
+import bio.terra.stairway.FlightContext;
+import com.azure.resourcemanager.securityinsights.models.AutomationRuleRunPlaybookAction;
+import com.azure.resourcemanager.securityinsights.models.AutomationRuleTriggeringLogic;
+import com.azure.resourcemanager.securityinsights.models.PlaybookActionProperties;
+import com.azure.resourcemanager.securityinsights.models.TriggersOn;
+import com.azure.resourcemanager.securityinsights.models.TriggersWhen;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CreateSentinelRunPlaybookAutomationRule extends BaseResourceCreateStep {
+  private static final Logger logger =
+      LoggerFactory.getLogger(CreateSentinelRunPlaybookAutomationRule.class);
+
+  private final LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration;
+
+  public CreateSentinelRunPlaybookAutomationRule(
+      ArmManagers armManagers,
+      ParametersResolver parametersResolver,
+      ResourceNameGenerator resourceNameGenerator,
+      LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration) {
+    super(armManagers, parametersResolver, resourceNameGenerator);
+    this.landingZoneProtectedDataConfiguration = landingZoneProtectedDataConfiguration;
+  }
+
+  @Override
+  protected void createResource(FlightContext context, ArmManagers armManagers) {
+    var workspace =
+        getParameterOrThrow(
+            context.getWorkingMap(),
+            CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_RESOURCE_KEY,
+            LandingZoneResource.class);
+
+    var trigger =
+        new AutomationRuleTriggeringLogic()
+            .withTriggersWhen(TriggersWhen.CREATED)
+            .withTriggersOn(TriggersOn.INCIDENTS)
+            .withIsEnabled(true);
+    var runPlaybookAction =
+        new AutomationRuleRunPlaybookAction()
+            .withOrder(1)
+            .withActionConfiguration(
+                new PlaybookActionProperties()
+                    .withLogicAppResourceId(
+                        landingZoneProtectedDataConfiguration.getLogicAppResourceId())
+                    .withTenantId(
+                        UUID.fromString(landingZoneProtectedDataConfiguration.getTenantId())));
+    var automationRule =
+        armManagers
+            .securityInsightsManager()
+            .automationRules()
+            .define("runSendSlackNotificationPlaybook")
+            .withExistingWorkspace(getMRGName(context), workspace.resourceName().get())
+            .withDisplayName("Run Slack Notification Playbook")
+            .withOrder(1)
+            .withTriggeringLogic(trigger)
+            .withActions(List.of(runPlaybookAction))
+            .create();
+    logger.info(RESOURCE_CREATED, getResourceType(), automationRule.id(), getMRGName(context));
+  }
+
+  @Override
+  protected void deleteResource(String resourceId) {
+    // nothing to delete here since an automation rule will be deleted together with sentinel
+  }
+
+  @Override
+  protected String getResourceType() {
+    return "SentinelAutomationRule";
+  }
+
+  @Override
+  protected Optional<String> getResourceId(FlightContext context) {
+    return Optional.empty();
+  }
+}

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelStep.java
@@ -1,0 +1,67 @@
+package bio.terra.landingzone.stairway.flight.create.resource.step;
+
+import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
+import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
+import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
+import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
+import bio.terra.stairway.FlightContext;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CreateSentinelStep extends BaseResourceCreateStep {
+  private static final Logger logger = LoggerFactory.getLogger(CreateSentinelStep.class);
+  public static final String SENTINEL_ID = "SENTINEL_ID";
+  public static final String SENTINEL_RESOURCE_KEY = "SENTINEL";
+
+  public CreateSentinelStep(
+      ArmManagers armManagers,
+      ParametersResolver parametersResolver,
+      ResourceNameGenerator resourceNameGenerator) {
+    super(armManagers, parametersResolver, resourceNameGenerator);
+  }
+
+  @Override
+  protected void createResource(FlightContext context, ArmManagers armManagers) {
+    var workspace =
+        getParameterOrThrow(
+            context.getWorkingMap(),
+            CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_RESOURCE_KEY,
+            LandingZoneResource.class);
+
+    var state =
+        armManagers
+            .securityInsightsManager()
+            .sentinelOnboardingStates()
+            .define("default")
+            .withExistingWorkspace(getMRGName(context), workspace.resourceName().get())
+            .create();
+
+    context.getWorkingMap().put(SENTINEL_ID, state.id());
+    context
+        .getWorkingMap()
+        .put(
+            SENTINEL_RESOURCE_KEY,
+            LandingZoneResource.builder()
+                .resourceId(state.id())
+                .resourceType(state.type())
+                .resourceName(state.name())
+                .build());
+    logger.info(RESOURCE_CREATED, getResourceType(), state.id(), getMRGName(context));
+  }
+
+  @Override
+  protected void deleteResource(String resourceId) {
+    armManagers.securityInsightsManager().sentinelOnboardingStates().deleteById(resourceId);
+  }
+
+  @Override
+  protected String getResourceType() {
+    return "Sentinel";
+  }
+
+  @Override
+  protected Optional<String> getResourceId(FlightContext context) {
+    return Optional.ofNullable(context.getWorkingMap().get(SENTINEL_ID, String.class));
+  }
+}

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelStep.java
@@ -4,6 +4,7 @@ import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
+import bio.terra.landingzone.stairway.flight.exception.MissingRequiredFieldsException;
 import bio.terra.stairway.FlightContext;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -28,6 +29,10 @@ public class CreateSentinelStep extends BaseResourceCreateStep {
             context.getWorkingMap(),
             CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_RESOURCE_KEY,
             LandingZoneResource.class);
+
+    if (workspace.resourceName().isEmpty()) {
+      throw new MissingRequiredFieldsException("LogAnalyticsWorkspace resource name is not set.");
+    }
 
     var state =
         armManagers

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelStep.java
@@ -24,13 +24,14 @@ public class CreateSentinelStep extends BaseResourceCreateStep {
 
   @Override
   protected void createResource(FlightContext context, ArmManagers armManagers) {
-    var workspace =
+    var logAnalyticsWorkspace =
         getParameterOrThrow(
             context.getWorkingMap(),
             CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_RESOURCE_KEY,
             LandingZoneResource.class);
 
-    if (workspace.resourceName().isEmpty()) {
+    var logAnalyticsWorkspaceResourceName = logAnalyticsWorkspace.resourceName();
+    if (logAnalyticsWorkspaceResourceName.isEmpty()) {
       throw new MissingRequiredFieldsException("LogAnalyticsWorkspace resource name is not set.");
     }
 
@@ -39,7 +40,7 @@ public class CreateSentinelStep extends BaseResourceCreateStep {
             .securityInsightsManager()
             .sentinelOnboardingStates()
             .define("default")
-            .withExistingWorkspace(getMRGName(context), workspace.resourceName().get())
+            .withExistingWorkspace(getMRGName(context), logAnalyticsWorkspaceResourceName.get())
             .create();
 
     context.getWorkingMap().put(SENTINEL_ID, state.id());

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/LandingZoneTestFixture.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/LandingZoneTestFixture.java
@@ -25,7 +25,8 @@ public class LandingZoneTestFixture {
             TestArmResourcesFactory.createPostgreSqlArmClient(),
             TestArmResourcesFactory.createLogAnalyticsArmClient(),
             TestArmResourcesFactory.createMonitorArmClient(),
-            TestArmResourcesFactory.createApplicationInsightsArmClient());
+            TestArmResourcesFactory.createApplicationInsightsArmClient(),
+            TestArmResourcesFactory.createSecurityInsightsArmClient());
     resourceGroup =
         TestArmResourcesFactory.createTestResourceGroup(armManagers.azureResourceManager());
     tokenCredential = AzureIntegrationUtils.getAdminAzureCredentialsOrDie();

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/TestArmResourcesFactory.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/TestArmResourcesFactory.java
@@ -11,6 +11,7 @@ import com.azure.resourcemanager.monitor.MonitorManager;
 import com.azure.resourcemanager.postgresql.PostgreSqlManager;
 import com.azure.resourcemanager.relay.RelayManager;
 import com.azure.resourcemanager.resources.models.ResourceGroup;
+import com.azure.resourcemanager.securityinsights.SecurityInsightsManager;
 import java.util.Locale;
 import java.util.UUID;
 
@@ -31,7 +32,8 @@ public class TestArmResourcesFactory {
         createPostgreSqlArmClient(),
         createLogAnalyticsArmClient(),
         createMonitorArmClient(),
-        createApplicationInsightsArmClient());
+        createApplicationInsightsArmClient(),
+        createSecurityInsightsArmClient());
   }
 
   public static RelayManager createRelayArmClient() {
@@ -66,6 +68,12 @@ public class TestArmResourcesFactory {
 
   public static ApplicationInsightsManager createApplicationInsightsArmClient() {
     return ApplicationInsightsManager.authenticate(
+        AzureIntegrationUtils.getAdminAzureCredentialsOrDie(),
+        AzureIntegrationUtils.TERRA_DEV_AZURE_PROFILE);
+  }
+
+  public static SecurityInsightsManager createSecurityInsightsArmClient() {
+    return SecurityInsightsManager.authenticate(
         AzureIntegrationUtils.getAdminAzureCredentialsOrDie(),
         AzureIntegrationUtils.TERRA_DEV_AZURE_PROFILE);
   }

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/DeployedLandingZoneDefinitionProviderImplTest.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/DeployedLandingZoneDefinitionProviderImplTest.java
@@ -14,7 +14,7 @@ class DeployedLandingZoneDefinitionProviderImplTest {
 
   @BeforeEach
   void setUp() {
-    ArmManagers armManagers = new ArmManagers(null, null, null, null, null, null, null);
+    ArmManagers armManagers = new ArmManagers(null, null, null, null, null, null, null, null);
     provider = new LandingZoneDefinitionProviderImpl(armManagers);
   }
 

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/management/deleterules/BaseDependencyRuleFixture.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/management/deleterules/BaseDependencyRuleFixture.java
@@ -14,6 +14,7 @@ import com.azure.resourcemanager.monitor.MonitorManager;
 import com.azure.resourcemanager.postgresql.PostgreSqlManager;
 import com.azure.resourcemanager.relay.RelayManager;
 import com.azure.resourcemanager.resources.models.GenericResource;
+import com.azure.resourcemanager.securityinsights.SecurityInsightsManager;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -36,6 +37,7 @@ public class BaseDependencyRuleFixture {
   @Mock protected LogAnalyticsManager logAnalyticsManager;
   @Mock protected MonitorManager monitorManager;
   @Mock protected ApplicationInsightsManager applicationInsightsManager;
+  @Mock protected SecurityInsightsManager securityInsightsManager;
 
   @Mock protected ResourceToDelete resourceToDelete;
   @Mock protected GenericResource resource;
@@ -50,7 +52,8 @@ public class BaseDependencyRuleFixture {
             postgreSqlManager,
             logAnalyticsManager,
             monitorManager,
-            applicationInsightsManager);
+            applicationInsightsManager,
+            securityInsightsManager);
   }
 
   protected void setUpResourceToDelete() {

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/BaseStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/BaseStepTest.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.mockito.Mock;
 
-public class BaseStepTest {
+class BaseStepTest {
   protected static final UUID LANDING_ZONE_ID = UUID.randomUUID();
   protected static final String VNET_NAME = "vNet";
   protected static final String VNET_ID = "networkId";

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/BaseStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/BaseStepTest.java
@@ -1,0 +1,50 @@
+package bio.terra.landingzone.stairway.flight.create.resource.step;
+
+import static org.mockito.Mockito.when;
+
+import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
+import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
+import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
+import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
+import bio.terra.landingzone.stairway.flight.FlightTestUtils;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.mockito.Mock;
+
+public class BaseStepTest {
+  protected static final UUID LANDING_ZONE_ID = UUID.randomUUID();
+  protected static final String VNET_NAME = "vNet";
+  protected static final String VNET_ID = "networkId";
+
+  @Mock protected ArmManagers mockArmManagers;
+  @Mock protected ParametersResolver mockParametersResolver;
+  @Mock protected ResourceNameGenerator mockResourceNameGenerator;
+  @Mock protected FlightContext mockFlightContext;
+
+  protected void setupFlightContext(
+      FlightContext flightContext,
+      Map<String, Object> inputParameters,
+      Map<String, Object> workingMap) {
+    if (inputParameters != null) {
+      FlightMap inputParamsMap = FlightTestUtils.prepareFlightInputParameters(inputParameters);
+      when(flightContext.getInputParameters()).thenReturn(inputParamsMap);
+    }
+    if (workingMap != null) {
+      FlightMap workingParamMap = FlightTestUtils.prepareFlightWorkingParameters(workingMap);
+      when(flightContext.getWorkingMap()).thenReturn(workingParamMap);
+    }
+  }
+
+  protected static LandingZoneResource buildLandingZoneResource() {
+    return new LandingZoneResource(
+        "resourceId",
+        "resourceType",
+        Map.of(),
+        "region",
+        Optional.of("resourceName"),
+        Optional.empty());
+  }
+}

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelRunPlaybookAutomationRuleTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelRunPlaybookAutomationRuleTest.java
@@ -1,0 +1,148 @@
+package bio.terra.landingzone.stairway.flight.create.resource.step;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfiguration;
+import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
+import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.exception.MissingRequiredFieldsException;
+import bio.terra.profile.model.ProfileModel;
+import bio.terra.stairway.StepResult;
+import com.azure.resourcemanager.securityinsights.SecurityInsightsManager;
+import com.azure.resourcemanager.securityinsights.models.AutomationRule;
+import com.azure.resourcemanager.securityinsights.models.AutomationRules;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("unit")
+class CreateSentinelRunPlaybookAutomationRuleTest extends BaseStepTest {
+
+  @Mock LandingZoneProtectedDataConfiguration mockLandingZoneProtectedDataConfiguration;
+  @Mock SecurityInsightsManager mockSecurityInsightsManager;
+  @Mock AutomationRules mockAutomationRules;
+  @Mock AutomationRule.DefinitionStages.Blank mockAutomationRuleDefinitionStageBlank;
+
+  @Mock
+  AutomationRule.DefinitionStages.WithDisplayName mockAutomationRuleDefinitionStageWithDisplayName;
+
+  @Mock AutomationRule.DefinitionStages.WithOrder mockAutomationRuleDefinitionStageWithOrder;
+
+  @Mock
+  AutomationRule.DefinitionStages.WithTriggeringLogic
+      mockAutomationRuleDefinitionStageWithTriggerLogic;
+
+  @Mock AutomationRule.DefinitionStages.WithActions mockAutomationRuleDefinitionStageWithActions;
+  @Mock AutomationRule.DefinitionStages.WithCreate mockAutomationRuleDefinitionStageWithCreate;
+  @Mock AutomationRule mockAutomationRule;
+
+  private CreateSentinelRunPlaybookAutomationRule createSentinelRunPlaybookAutomationRule;
+
+  @BeforeEach
+  void setUp() {
+    createSentinelRunPlaybookAutomationRule =
+        new CreateSentinelRunPlaybookAutomationRule(
+            mockArmManagers,
+            mockParametersResolver,
+            mockResourceNameGenerator,
+            mockLandingZoneProtectedDataConfiguration);
+  }
+
+  @Test
+  void doStepSuccess() throws InterruptedException {
+    setupFlightContext(
+        mockFlightContext,
+        Map.of(
+            LandingZoneFlightMapKeys.BILLING_PROFILE,
+            new ProfileModel().id(UUID.randomUUID()),
+            LandingZoneFlightMapKeys.LANDING_ZONE_ID,
+            LANDING_ZONE_ID),
+        Map.of(
+            GetManagedResourceGroupInfo.TARGET_MRG_KEY,
+            new TargetManagedResourceGroup("mgrName", "mrgRegion"),
+            CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_RESOURCE_KEY,
+            buildLandingZoneResource()));
+    setupArmManagersForDoStep("ruleId");
+
+    when(mockLandingZoneProtectedDataConfiguration.getLogicAppResourceId())
+        .thenReturn("logicAppResourceId");
+    when(mockLandingZoneProtectedDataConfiguration.getTenantId())
+        .thenReturn(UUID.randomUUID().toString());
+
+    StepResult stepResult = createSentinelRunPlaybookAutomationRule.doStep(mockFlightContext);
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+    verify(mockAutomationRuleDefinitionStageWithCreate, times(1)).create();
+  }
+
+  @Test
+  void doStepMissingInputParameterThrowsException() {
+    setupFlightContext(
+        mockFlightContext,
+        Map.of(
+            LandingZoneFlightMapKeys.BILLING_PROFILE,
+            new ProfileModel().id(UUID.randomUUID()),
+            LandingZoneFlightMapKeys.LANDING_ZONE_ID,
+            LANDING_ZONE_ID),
+        Map.of());
+
+    // missing LOG_ANALYTICS_RESOURCE_KEY in workingMap
+    assertThrows(
+        MissingRequiredFieldsException.class,
+        () -> createSentinelRunPlaybookAutomationRule.doStep(mockFlightContext));
+  }
+
+  @Test
+  void undoStepSuccess() throws InterruptedException {
+    verifyUndoStep();
+  }
+
+  @Test
+  void undoStepSuccessWhenDoStepFailed() throws InterruptedException {
+    verifyUndoStep();
+  }
+
+  void verifyUndoStep() throws InterruptedException {
+    // deleteResource do nothing
+    assertThat(
+        createSentinelRunPlaybookAutomationRule.undoStep(mockFlightContext),
+        equalTo(StepResult.getStepResultSuccess()));
+  }
+
+  private void setupArmManagersForDoStep(String ruleId) {
+    when(mockAutomationRule.id()).thenReturn(ruleId);
+    when(mockAutomationRuleDefinitionStageWithCreate.create()).thenReturn(mockAutomationRule);
+    when(mockAutomationRuleDefinitionStageWithActions.withActions(any()))
+        .thenReturn(mockAutomationRuleDefinitionStageWithCreate);
+    when(mockAutomationRuleDefinitionStageWithTriggerLogic.withTriggeringLogic(any()))
+        .thenReturn(mockAutomationRuleDefinitionStageWithActions);
+    when(mockAutomationRuleDefinitionStageWithOrder.withOrder(anyInt()))
+        .thenReturn(mockAutomationRuleDefinitionStageWithTriggerLogic);
+    when(mockAutomationRuleDefinitionStageWithDisplayName.withDisplayName(anyString()))
+        .thenReturn(mockAutomationRuleDefinitionStageWithOrder);
+    when(mockAutomationRuleDefinitionStageBlank.withExistingWorkspace(anyString(), anyString()))
+        .thenReturn(mockAutomationRuleDefinitionStageWithDisplayName);
+    when(mockAutomationRules.define(anyString()))
+        .thenReturn(mockAutomationRuleDefinitionStageBlank);
+    when(mockSecurityInsightsManager.automationRules()).thenReturn(mockAutomationRules);
+    when(mockArmManagers.securityInsightsManager()).thenReturn(mockSecurityInsightsManager);
+  }
+
+  private void setupArmManagersForUndoStep(String ruleId) {
+    when(mockSecurityInsightsManager.automationRules()).thenReturn(mockAutomationRules);
+    when(mockArmManagers.securityInsightsManager()).thenReturn(mockSecurityInsightsManager);
+  }
+}

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelStepTest.java
@@ -1,0 +1,124 @@
+package bio.terra.landingzone.stairway.flight.create.resource.step;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
+import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.exception.MissingRequiredFieldsException;
+import bio.terra.profile.model.ProfileModel;
+import bio.terra.stairway.StepResult;
+import com.azure.resourcemanager.securityinsights.SecurityInsightsManager;
+import com.azure.resourcemanager.securityinsights.models.SentinelOnboardingState;
+import com.azure.resourcemanager.securityinsights.models.SentinelOnboardingStates;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("unit")
+class CreateSentinelStepTest extends BaseStepTest {
+  private static final String RESOURCE_ID = "sentinelId";
+
+  @Mock SecurityInsightsManager mockSecurityInsightsManager;
+  @Mock SentinelOnboardingStates mockSentinelOnboardingStages;
+  @Mock SentinelOnboardingState.DefinitionStages.Blank mockDefinitionStagesBlank;
+  @Mock SentinelOnboardingState.DefinitionStages.WithCreate mockDefinitionStagesWithCreate;
+  @Mock SentinelOnboardingState mockSentinelOnboardingState;
+
+  private CreateSentinelStep createSentinelStep;
+
+  @BeforeEach
+  void setUp() {
+    createSentinelStep =
+        new CreateSentinelStep(mockArmManagers, mockParametersResolver, mockResourceNameGenerator);
+  }
+
+  @Test
+  void doStepSuccess() throws InterruptedException {
+    setupFlightContext(
+        mockFlightContext,
+        Map.of(
+            LandingZoneFlightMapKeys.BILLING_PROFILE,
+            new ProfileModel().id(UUID.randomUUID()),
+            LandingZoneFlightMapKeys.LANDING_ZONE_ID,
+            LANDING_ZONE_ID),
+        Map.of(
+            GetManagedResourceGroupInfo.TARGET_MRG_KEY,
+            new TargetManagedResourceGroup("mgrName", "mrgRegion"),
+            CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_RESOURCE_KEY,
+            buildLandingZoneResource()));
+    setupArmManagersForDoStep(RESOURCE_ID);
+
+    StepResult stepResult = createSentinelStep.doStep(mockFlightContext);
+
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+    verify(mockDefinitionStagesWithCreate, times(1)).create();
+  }
+
+  @Test
+  void doStepMissingInputParameterThrowsException() {
+    setupFlightContext(
+        mockFlightContext,
+        Map.of(
+            LandingZoneFlightMapKeys.BILLING_PROFILE,
+            new ProfileModel().id(UUID.randomUUID()),
+            LandingZoneFlightMapKeys.LANDING_ZONE_ID,
+            LANDING_ZONE_ID),
+        Map.of());
+
+    // missing LOG_ANALYTICS_RESOURCE_KEY in workingMap
+    assertThrows(
+        MissingRequiredFieldsException.class, () -> createSentinelStep.doStep(mockFlightContext));
+  }
+
+  @Test
+  void undoStepSuccess() throws InterruptedException {
+    setupFlightContext(
+        mockFlightContext, null, Map.of(CreateSentinelStep.SENTINEL_ID, RESOURCE_ID));
+    setupArmManagersForUndoStep();
+
+    StepResult stepResult = createSentinelStep.undoStep(mockFlightContext);
+
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+    verify(mockSentinelOnboardingStages, times(1)).deleteById(RESOURCE_ID);
+  }
+
+  @Test
+  void undoStepSuccessWhenDoStepFailed() throws InterruptedException {
+    setupFlightContext(mockFlightContext, null, Map.of());
+
+    var stepResult = createSentinelStep.undoStep(mockFlightContext);
+
+    verify(mockSentinelOnboardingStages, never()).deleteById(VNET_ID);
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+  }
+
+  private void setupArmManagersForDoStep(String resourceId) {
+    when(mockSentinelOnboardingState.id()).thenReturn(resourceId);
+    when(mockDefinitionStagesWithCreate.create()).thenReturn(mockSentinelOnboardingState);
+    when(mockDefinitionStagesBlank.withExistingWorkspace(anyString(), anyString()))
+        .thenReturn(mockDefinitionStagesWithCreate);
+    when(mockSentinelOnboardingStages.define(anyString())).thenReturn(mockDefinitionStagesBlank);
+    when(mockSecurityInsightsManager.sentinelOnboardingStates())
+        .thenReturn(mockSentinelOnboardingStages);
+    when(mockArmManagers.securityInsightsManager()).thenReturn(mockSecurityInsightsManager);
+  }
+
+  private void setupArmManagersForUndoStep() {
+    when(mockSecurityInsightsManager.sentinelOnboardingStates())
+        .thenReturn(mockSentinelOnboardingStages);
+    when(mockArmManagers.securityInsightsManager()).thenReturn(mockSecurityInsightsManager);
+  }
+}

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateVnetStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateVnetStepTest.java
@@ -12,16 +12,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.CromwellBaseResourcesFactory;
-import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
 import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
 import bio.terra.landingzone.stairway.flight.FlightTestUtils;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
 import bio.terra.landingzone.stairway.flight.exception.MissingRequiredFieldsException;
 import bio.terra.profile.model.ProfileModel;
-import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import com.azure.resourcemanager.AzureResourceManager;
@@ -42,16 +39,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 @Tag("unit")
-class CreateVnetStepTest {
-  private static final UUID LANDING_ZONE_ID = UUID.randomUUID();
-  private static final String VNET_NAME = "vNet";
-  private static final String VNET_ID = "networkId";
-
-  @Mock private ArmManagers mockArmManagers;
-  @Mock private ParametersResolver mockParametersResolver;
-  @Mock private ResourceNameGenerator mockResourceNameGenerator;
-  @Mock private FlightContext mockFlightContext;
-
+class CreateVnetStepTest extends BaseStepTest {
   @Mock private AzureResourceManager mockAzureResourceManager;
   @Mock private Networks mockNetworks;
   @Mock private Network.DefinitionStages.Blank mockDefinitionStageBlack;
@@ -73,6 +61,7 @@ class CreateVnetStepTest {
         .thenReturn(VNET_NAME);
 
     setupFlightContext(
+        mockFlightContext,
         Map.of(
             LandingZoneFlightMapKeys.BILLING_PROFILE,
             new ProfileModel().id(UUID.randomUUID()),
@@ -132,14 +121,6 @@ class CreateVnetStepTest {
 
     verify(mockNetworks, never()).deleteById(VNET_ID);
     assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
-  }
-
-  private void setupFlightContext(
-      Map<String, Object> inputParameters, Map<String, Object> workingMap) {
-    FlightMap inputParamsMap = FlightTestUtils.prepareFlightInputParameters(inputParameters);
-    FlightMap workingParamMap = FlightTestUtils.prepareFlightWorkingParameters(workingMap);
-    when(mockFlightContext.getInputParameters()).thenReturn(inputParamsMap);
-    when(mockFlightContext.getWorkingMap()).thenReturn(workingParamMap);
   }
 
   private void setupArmManagers(Network result) {

--- a/service/src/test/resources/application-test.yml
+++ b/service/src/test/resources/application-test.yml
@@ -30,6 +30,10 @@ landingzone:
     resource-id: mc-terra-workspace-manager
     timeout-seconds: 1800
 
+  protected-data:
+    logic-app-resource-id: [ PUT VALUE HERE ]
+    tenant-id: [ PUT VALUE HERE ]
+
 terra.common:
   kubernetes:
     in-kubernetes: false

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 rootProject.name = 'terra-landing-zone-service'
 include('service', 'scripts', 'testharness')
 
-gradle.ext.releaseVersion = "0.0.78-WOR-941-11-SNAPSHOT"
+gradle.ext.releaseVersion = "0.0.78-SNAPSHOT"
 include 'testharness'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 rootProject.name = 'terra-landing-zone-service'
 include('service', 'scripts', 'testharness')
 
-gradle.ext.releaseVersion = "0.0.78-SNAPSHOT"
+gradle.ext.releaseVersion = "0.0.78-WOR-941-11-SNAPSHOT"
 include 'testharness'
 

--- a/testharness/src/main/resources/application.yml
+++ b/testharness/src/main/resources/application.yml
@@ -65,6 +65,11 @@ landingzone:
     resource-id: mc-terra-workspace-manager
     timeout-seconds: 1800
 
+  protected-data:
+    logic-app-resource-id: [PUT VALUE HERE]
+    tenant-id: [PUT VALUE HERE]
+
+
 terra.common:
   kubernetes:
     in-kubernetes: false


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-941

This PR introduces:
-Sentinel as a part of a protected landing zone 
-Automation rule for slack notification. This rule triggers playbook (Logic App) in a "central" Sentinel.
-Configuration which points to a certain playbook (Logic App). This configuration doesn't have any values here since it should be set in WSM (at least while we are using amalgamated approach).


