### PR TITLE
[WOR-1001] Bump jose4j

### DIFF
--- a/buildSrc/src/main/groovy/bio.terra.landingzone.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.landingzone.java-common-conventions.gradle
@@ -45,7 +45,7 @@ dependencies {
     testImplementation 'ch.qos.logback:logback-classic:1.2.10'
     testImplementation 'org.hamcrest:hamcrest:2.2'
 
-    implementation ('bio.terra:terra-common-lib:0.0.75-SNAPSHOT'){
+    implementation ('bio.terra:terra-common-lib:0.0.88-SNAPSHOT'){
         exclude group: "org.broadinstitute.dsde.workbench", module: "sam-client_2.13"
     }
 }

--- a/testharness/build.gradle
+++ b/testharness/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-inline:5.2.0'
 
     jacocoTestReport {
+        dependsOn(':service:compileTestJava')
         reports {
             // sonarqube requires XML coverage output to upload coverage data
             xml.required = true


### PR DESCRIPTION
Ticket: [WOR-1001](https://broadworkbench.atlassian.net/browse/WOR-1001)
* bump TCL to use non-vulnerable version of jose4j
<img width="508" alt="Screenshot 2023-05-17 at 4 09 54 PM" src="https://github.com/DataBiosphere/terra-landing-zone-service/assets/19961550/0ae7d72e-1c72-4be2-9a27-626e3e186336">


* `./gradlew build` was failing for me with the following error:
```
A problem was found with the configuration of task ':testharness:jacocoTestReport' (type 'JacocoReport').
  - Gradle detected a problem with the following location: '/Users/mtalbott/ws/broad/terra-landing-zone-service/service/build/classes'.
    
    Reason: Task ':testharness:jacocoTestReport' uses this output of task ':service:compileTestJava' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
```

This was happening on `main` as well as my branch, but adding the `dependsOn` to `:testharness:jacocoTestReport` fixed it

[WOR-1001]: https://broadworkbench.atlassian.net/browse/WOR-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ