### PR TITLE
[WOR-1003] Do not allow container ACLs to ever allow anonymous blob access

### DIFF
--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAccountStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAccountStep.java
@@ -40,6 +40,7 @@ public class CreateStorageAccountStep extends BaseResourceCreateStep {
             .define(storageAccountName)
             .withRegion(getMRGRegionName(context))
             .withExistingResourceGroup(getMRGName(context))
+            .disableBlobPublicAccess()
             .withTags(
                 Map.of(
                     LandingZoneTagKeys.LANDING_ZONE_ID.toString(),


### PR DESCRIPTION
This disables the ability to allow anonymous blob access on child storage containers of a landing zone storage account. 