### PR TITLE
WOR-995 reapply changes for stairway integration tests

### DIFF
--- a/scripts/write-config.sh
+++ b/scripts/write-config.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Note: for local develepment, use the service/render-test-config.sh instead.
+# I'm not 100% sure this isn't used anywhere, but I suspect this file is an artifact of a different project or some such
 #
 # write-config.sh extracts configuration information from vault and writes it to a set of files
 # in a directory. This simplifies access to the secrets from other scripts and applications.

--- a/service/render-test-config.sh
+++ b/service/render-test-config.sh
@@ -15,11 +15,6 @@ docker run --rm --cap-add IPC_LOCK \
             vault read -format json ${VAULT_AZURE_MANAGED_APP_CLIENT_PATH} \
             | jq -r .data > ${AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH}
 
-# The docker image above doesn't have an image that will run on ARM architecture (such as the apple m1 chip)
-# The command below is an alternative with an installed version of vault
-# VAULT_ADDR="https://clotho.broadinstitute.org:8200"
-# vault read -format=json "${VAULT_AZURE_MANAGED_APP_CLIENT_PATH}" | jq -r .data > ${AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH}
-
 AZURE_MANAGED_APP_CLIENT_ID=$(jq -r '."client-id"' ${AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH})
 AZURE_MANAGED_APP_CLIENT_SECRET=$(jq -r '."client-secret"' ${AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH})
 AZURE_MANAGED_APP_TENANT_ID=$(jq -r '."tenant-id"' ${AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH})

--- a/service/render-test-config.sh
+++ b/service/render-test-config.sh
@@ -19,7 +19,7 @@ AZURE_MANAGED_APP_CLIENT_ID=$(jq -r '."client-id"' ${AZURE_MANAGED_APP_CLIENT_OU
 AZURE_MANAGED_APP_CLIENT_SECRET=$(jq -r '."client-secret"' ${AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH})
 AZURE_MANAGED_APP_TENANT_ID=$(jq -r '."tenant-id"' ${AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH})
 cat > ${AZURE_PROPERTIES_OUTPUT_FILE_PATH} <<EOF
-integration.azure.admin.clientId=${AZURE_MANAGED_APP_CLIENT_ID}
-integration.azure.admin.clientSecret=${AZURE_MANAGED_APP_CLIENT_SECRET}
-integration.azure.admin.tenantId=${AZURE_MANAGED_APP_TENANT_ID}
+workspace.azure.managedAppClientId=${AZURE_MANAGED_APP_CLIENT_ID}
+workspace.azure.managedAppClientSecret=${AZURE_MANAGED_APP_CLIENT_SECRET}
+workspace.azure.managedAppTenantId=${AZURE_MANAGED_APP_TENANT_ID}
 EOF

--- a/service/render-test-config.sh
+++ b/service/render-test-config.sh
@@ -15,6 +15,11 @@ docker run --rm --cap-add IPC_LOCK \
             vault read -format json ${VAULT_AZURE_MANAGED_APP_CLIENT_PATH} \
             | jq -r .data > ${AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH}
 
+# The docker image above doesn't have an image that will run on ARM architecture (such as the apple m1 chip)
+# The command below is an alternative with an installed version of vault
+# VAULT_ADDR="https://clotho.broadinstitute.org:8200"
+# vault read -format=json "${VAULT_AZURE_MANAGED_APP_CLIENT_PATH}" | jq -r .data > ${AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH}
+
 AZURE_MANAGED_APP_CLIENT_ID=$(jq -r '."client-id"' ${AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH})
 AZURE_MANAGED_APP_CLIENT_SECRET=$(jq -r '."client-secret"' ${AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH})
 AZURE_MANAGED_APP_TENANT_ID=$(jq -r '."tenant-id"' ${AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH})

--- a/service/src/main/java/bio/terra/landingzone/library/configuration/LandingZoneAzureConfiguration.java
+++ b/service/src/main/java/bio/terra/landingzone/library/configuration/LandingZoneAzureConfiguration.java
@@ -1,5 +1,8 @@
 package bio.terra.landingzone.library.configuration;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "workspace.azure")
 public class LandingZoneAzureConfiguration {
   // Managed app authentication
   private String managedAppClientId;

--- a/service/src/main/java/bio/terra/landingzone/library/configuration/stairway/LandingZoneStairwayConfiguration.java
+++ b/service/src/main/java/bio/terra/landingzone/library/configuration/stairway/LandingZoneStairwayConfiguration.java
@@ -6,20 +6,17 @@ import bio.terra.common.stairway.StairwayComponent;
 import bio.terra.common.stairway.StairwayProperties;
 import bio.terra.landingzone.library.configuration.LandingZoneAzureConfiguration;
 import bio.terra.landingzone.library.configuration.LandingZoneStairwayProperties;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class LandingZoneStairwayConfiguration {
   @Bean
-  @ConfigurationProperties(prefix = "landingzone.stairway")
   public LandingZoneStairwayProperties getLandingZoneStairwayProperties() {
     return new LandingZoneStairwayProperties();
   }
 
   @Bean
-  @ConfigurationProperties(prefix = "workspace.azure")
   public LandingZoneAzureConfiguration getLandingZoneAzureConfiguration() {
     return new LandingZoneAzureConfiguration();
   }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/AggregateLandingZoneResourcesStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/AggregateLandingZoneResourcesStep.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 
 public class AggregateLandingZoneResourcesStep implements Step {
   // TODO: only shared resources?
-  private List<String> deployedResourcesKeys =
+  public static List<String> deployedResourcesKeys =
       List.of(
           CreateVnetStep.VNET_RESOURCE_KEY,
           CreateBatchAccountStep.BATCH_ACCOUNT_RESOURCE_KEY,

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/AggregateLandingZoneResourcesStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/AggregateLandingZoneResourcesStep.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 
 public class AggregateLandingZoneResourcesStep implements Step {
   // TODO: only shared resources?
-  public static List<String> deployedResourcesKeys =
+  public static final List<String> deployedResourcesKeys =
       List.of(
           CreateVnetStep.VNET_RESOURCE_KEY,
           CreateBatchAccountStep.BATCH_ACCOUNT_RESOURCE_KEY,

--- a/service/src/test/java/bio/terra/landingzone/app/StartupInitializer.java
+++ b/service/src/test/java/bio/terra/landingzone/app/StartupInitializer.java
@@ -1,0 +1,15 @@
+package bio.terra.landingzone.app;
+
+import bio.terra.common.migrate.LiquibaseMigrator;
+import bio.terra.landingzone.library.LandingZoneMain;
+import org.springframework.context.ApplicationContext;
+
+public class StartupInitializer {
+  private static final String CHANGELOG_PATH = "landingzonedb/changelog.xml";
+
+  public static void initialize(ApplicationContext applicationContext) {
+    // Initialize the Terra Landing Zone Service library
+    LiquibaseMigrator migrateService = applicationContext.getBean(LiquibaseMigrator.class);
+    LandingZoneMain.initialize(applicationContext, migrateService);
+  }
+}

--- a/service/src/test/java/bio/terra/landingzone/app/TestBeanConfig.java
+++ b/service/src/test/java/bio/terra/landingzone/app/TestBeanConfig.java
@@ -1,0 +1,14 @@
+package bio.terra.landingzone.app;
+
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TestBeanConfig {
+  @Bean
+  public SmartInitializingSingleton postSetupInitialization(ApplicationContext applicationContext) {
+    return () -> StartupInitializer.initialize(applicationContext);
+  }
+}

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/AzureIntegrationUtils.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/AzureIntegrationUtils.java
@@ -12,12 +12,13 @@ import java.util.Properties;
 import org.assertj.core.util.Strings;
 
 public class AzureIntegrationUtils {
+
   /** Path to Azure properties file. */
   private static final String AZURE_PROPERTIES_PATH =
-      "application-integration_azure_env.properties";
+      "integration_azure_env.properties";
 
   /** Property prefix for properties in {@link #AZURE_PROPERTIES_PATH}. */
-  private static final String AZURE_PROPERTY_PREFIX = "workspace.azure";
+  private static final String AZURE_PROPERTY_PREFIX = "workspace.azure.";
 
   private static final String CLIENT_ID_ENV_VAR = "AZURE_PUBLISHER_CLIENT_ID";
   private static final String CLIENT_SECRET_ENV_VAR = "AZURE_PUBLISHER_CLIENT_SECRET";

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/AzureIntegrationUtils.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/AzureIntegrationUtils.java
@@ -13,10 +13,11 @@ import org.assertj.core.util.Strings;
 
 public class AzureIntegrationUtils {
   /** Path to Azure properties file. */
-  private static final String AZURE_PROPERTIES_PATH = "integration_azure_env.properties";
+  private static final String AZURE_PROPERTIES_PATH =
+      "application-integration_azure_env.properties";
 
   /** Property prefix for properties in {@link #AZURE_PROPERTIES_PATH}. */
-  private static final String AZURE_PROPERTY_PREFIX = "integration.azure";
+  private static final String AZURE_PROPERTY_PREFIX = "workspace.azure";
 
   private static final String CLIENT_ID_ENV_VAR = "AZURE_PUBLISHER_CLIENT_ID";
   private static final String CLIENT_SECRET_ENV_VAR = "AZURE_PUBLISHER_CLIENT_SECRET";
@@ -51,17 +52,17 @@ public class AzureIntegrationUtils {
 
       final String clientId =
           Preconditions.checkNotNull(
-              properties.getProperty(AZURE_PROPERTY_PREFIX + ".admin.clientId"),
+              properties.getProperty(AZURE_PROPERTY_PREFIX + "managedAppClientId"),
               "Unable to read Azure admin client id from " + AZURE_PROPERTIES_PATH);
 
       final String clientSecret =
           Preconditions.checkNotNull(
-              properties.getProperty(AZURE_PROPERTY_PREFIX + ".admin.clientSecret"),
+              properties.getProperty(AZURE_PROPERTY_PREFIX + "managedAppClientSecret"),
               "Unable to read Azure admin application secret from " + AZURE_PROPERTIES_PATH);
 
       final String tenantId =
           Preconditions.checkNotNull(
-              properties.getProperty(AZURE_PROPERTY_PREFIX + ".admin.tenantId"),
+              properties.getProperty(AZURE_PROPERTY_PREFIX + "managedAppTenantId"),
               "Unable to read Azure admin tenant id from " + AZURE_PROPERTIES_PATH);
 
       return new ClientSecretCredentialBuilder()

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/AzureIntegrationUtils.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/AzureIntegrationUtils.java
@@ -14,8 +14,7 @@ import org.assertj.core.util.Strings;
 public class AzureIntegrationUtils {
 
   /** Path to Azure properties file. */
-  private static final String AZURE_PROPERTIES_PATH =
-      "integration_azure_env.properties";
+  private static final String AZURE_PROPERTIES_PATH = "integration_azure_env.properties";
 
   /** Property prefix for properties in {@link #AZURE_PROPERTIES_PATH}. */
   private static final String AZURE_PROPERTY_PREFIX = "workspace.azure.";

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
@@ -1,0 +1,125 @@
+package bio.terra.landingzone.stairway.flight.create;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import bio.terra.common.iam.BearerToken;
+import bio.terra.common.stairway.StairwayComponent;
+import bio.terra.landingzone.job.exception.InternalStairwayException;
+import bio.terra.landingzone.job.exception.JobNotFoundException;
+import bio.terra.landingzone.library.landingzones.LandingZoneTestFixture;
+import bio.terra.landingzone.service.landingzone.azure.LandingZoneService;
+import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneRequest;
+import bio.terra.landingzone.stairway.flight.StepsDefinitionFactoryType;
+import bio.terra.profile.model.CloudPlatform;
+import bio.terra.profile.model.ProfileModel;
+import bio.terra.stairway.FlightState;
+import bio.terra.stairway.FlightStatus;
+import bio.terra.stairway.exception.FlightNotFoundException;
+import bio.terra.stairway.exception.StairwayException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Tag("integration")
+@ExtendWith(SpringExtension.class)
+@SpringBootTest()
+
+@SpringBootApplication(
+    scanBasePackages = {
+        "bio.terra.common.logging",
+        "bio.terra.common.migrate",
+        "bio.terra.common.kubernetes",
+        "bio.terra.landingzone"
+    },
+    exclude = {DataSourceAutoConfiguration.class}
+    )
+@EnableRetry
+@EnableTransactionManagement
+public class CreateLandingZoneResourcesFlightIntegrationTest extends LandingZoneTestFixture {
+
+
+  @Mock private BearerToken bearerToken;
+
+  @Autowired LandingZoneService landingZoneService;
+
+  @Autowired
+  @Qualifier("landingZoneStairwayComponent")
+  StairwayComponent stairwayComponent;
+
+  UUID jobId;
+  UUID landingZoneId;
+  ProfileModel profile;
+  LandingZoneRequest request;
+
+  @BeforeEach
+  void setup() {
+    jobId = UUID.randomUUID();
+    landingZoneId = UUID.randomUUID();
+
+    profile =
+        new ProfileModel()
+            .managedResourceGroupId(resourceGroup.name())
+            .subscriptionId(UUID.fromString(azureProfile.getSubscriptionId()))
+            .tenantId(UUID.fromString(azureProfile.getTenantId()))
+            .cloudPlatform(CloudPlatform.AZURE)
+            .description("dummyProfile")
+            .id(UUID.randomUUID());
+    request =
+        new LandingZoneRequest(
+            StepsDefinitionFactoryType.PROTECTED_DATA_DEFINITION_STEPS_PROVIDER_NAME.getValue(),
+            "v1",
+            Map.of(),
+            profile.getId(),
+            Optional.of(landingZoneId),
+            true);
+  }
+
+  @Test
+  void test() {
+    String resultPath = "";
+    landingZoneService.startLandingZoneResourceCreationJob(
+        jobId.toString(), request, profile, landingZoneId, bearerToken, resultPath);
+
+    await()
+        .atMost(Duration.ofMinutes(20))
+        .untilAsserted(
+            () -> {
+              var flightState = retrieveFlightState(jobId.toString());
+              assertThat(flightState.getFlightStatus(), not(FlightStatus.RUNNING));
+            });
+    var flightState = retrieveFlightState(jobId.toString());
+    assertThat(flightState.getFlightStatus(), oneOf(FlightStatus.READY, FlightStatus.SUCCESS));
+  }
+
+
+  // just a clone of the method in LandingZoneService
+  // but using the stairwayComponent directly means we don't have to fuss around with authentication,
+  // which brings in the requirement for a lot more mocking
+  private FlightState retrieveFlightState(String jobId) {
+    try {
+      return stairwayComponent.get().getFlightState(jobId);
+    } catch (FlightNotFoundException flightNotFoundException) {
+      throw new JobNotFoundException(
+          "The flight " + jobId + " was not found", flightNotFoundException);
+    } catch (StairwayException | InterruptedException stairwayEx) {
+      throw new InternalStairwayException(stairwayEx);
+    }
+  }
+
+}

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
@@ -117,7 +117,7 @@ public class CreateLandingZoneResourcesFlightIntegrationTest extends LandingZone
               assertThat(flightState.getFlightStatus(), not(FlightStatus.RUNNING));
             });
     var flightState = retrieveFlightState(jobId.toString());
-    assertThat(flightState.getFlightStatus(), oneOf(FlightStatus.READY, FlightStatus.SUCCESS));
+    assertThat(flightState.getFlightStatus(), is(FlightStatus.SUCCESS));
 
     var lzIdString = landingZoneId.toString();
 

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
@@ -101,11 +101,6 @@ public class CreateLandingZoneResourcesFlightIntegrationTest extends LandingZone
             tokenCredential, azureProfile, resourceGroup.name());
   }
 
-  @AfterEach
-  void cleanUp() throws Exception {
-    landingZoneManager.deleteResources(landingZoneId.toString());
-  }
-
   @Test
   void createResourcesFlightDeploysCromwellResources() throws Exception {
     String resultPath = "";
@@ -126,18 +121,6 @@ public class CreateLandingZoneResourcesFlightIntegrationTest extends LandingZone
 
     var resources = landingZoneManager.reader().listSharedResources(lzIdString);
     assertThat(resources, hasSize(AggregateLandingZoneResourcesStep.deployedResourcesKeys.size()));
-
-    landingZoneManager.deleteResources(landingZoneId.toString());
-
-    // Immediate listing after deletion may return transient resources results.
-    await()
-        .atMost(Duration.ofSeconds(120))
-        .untilAsserted(
-            () -> {
-              var landingZoneResources =
-                  landingZoneManager.reader().listAllResources(landingZoneId.toString());
-              assertThat(landingZoneResources, empty());
-            });
   }
 
   // just a clone of the method in LandingZoneService

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -40,6 +41,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Tag("integration")
 @ActiveProfiles("test")
+@PropertySource("classpath:integration_azure_env.properties")
 @ExtendWith(SpringExtension.class)
 @SpringBootTest()
 @SpringBootApplication(

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
@@ -9,9 +9,11 @@ import bio.terra.common.stairway.StairwayComponent;
 import bio.terra.landingzone.job.exception.InternalStairwayException;
 import bio.terra.landingzone.job.exception.JobNotFoundException;
 import bio.terra.landingzone.library.landingzones.LandingZoneTestFixture;
+import bio.terra.landingzone.library.landingzones.management.LandingZoneManager;
 import bio.terra.landingzone.service.landingzone.azure.LandingZoneService;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneRequest;
 import bio.terra.landingzone.stairway.flight.StepsDefinitionFactoryType;
+import bio.terra.landingzone.stairway.flight.create.resource.step.AggregateLandingZoneResourcesStep;
 import bio.terra.profile.model.CloudPlatform;
 import bio.terra.profile.model.ProfileModel;
 import bio.terra.stairway.FlightState;
@@ -22,9 +24,8 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,26 +34,26 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Tag("integration")
+@ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 @SpringBootTest()
-
 @SpringBootApplication(
     scanBasePackages = {
-        "bio.terra.common.logging",
-        "bio.terra.common.migrate",
-        "bio.terra.common.kubernetes",
-        "bio.terra.landingzone"
+      "bio.terra.common.logging",
+      "bio.terra.common.migrate",
+      "bio.terra.common.kubernetes",
+      "bio.terra.common.stairway",
+      "bio.terra.landingzone"
     },
-    exclude = {DataSourceAutoConfiguration.class}
-    )
+    exclude = {DataSourceAutoConfiguration.class})
 @EnableRetry
 @EnableTransactionManagement
 public class CreateLandingZoneResourcesFlightIntegrationTest extends LandingZoneTestFixture {
-
 
   @Mock private BearerToken bearerToken;
 
@@ -66,9 +67,16 @@ public class CreateLandingZoneResourcesFlightIntegrationTest extends LandingZone
   UUID landingZoneId;
   ProfileModel profile;
   LandingZoneRequest request;
+  LandingZoneManager landingZoneManager;
+
+  @BeforeAll
+  static void init() {
+    Awaitility.setDefaultPollInterval(Duration.ofSeconds(5));
+  }
 
   @BeforeEach
   void setup() {
+
     jobId = UUID.randomUUID();
     landingZoneId = UUID.randomUUID();
 
@@ -82,16 +90,24 @@ public class CreateLandingZoneResourcesFlightIntegrationTest extends LandingZone
             .id(UUID.randomUUID());
     request =
         new LandingZoneRequest(
-            StepsDefinitionFactoryType.PROTECTED_DATA_DEFINITION_STEPS_PROVIDER_NAME.getValue(),
+            StepsDefinitionFactoryType.CROMWELL_BASE_DEFINITION_STEPS_PROVIDER_TYPE.getValue(),
             "v1",
             Map.of(),
             profile.getId(),
             Optional.of(landingZoneId),
             true);
+    landingZoneManager =
+        LandingZoneManager.createLandingZoneManager(
+            tokenCredential, azureProfile, resourceGroup.name());
+  }
+
+  @AfterEach
+  void cleanUp() throws Exception {
+    landingZoneManager.deleteResources(landingZoneId.toString());
   }
 
   @Test
-  void test() {
+  void createResourcesFlightDeploysCromwellResources() throws Exception {
     String resultPath = "";
     landingZoneService.startLandingZoneResourceCreationJob(
         jobId.toString(), request, profile, landingZoneId, bearerToken, resultPath);
@@ -105,11 +121,28 @@ public class CreateLandingZoneResourcesFlightIntegrationTest extends LandingZone
             });
     var flightState = retrieveFlightState(jobId.toString());
     assertThat(flightState.getFlightStatus(), oneOf(FlightStatus.READY, FlightStatus.SUCCESS));
+
+    var lzIdString = landingZoneId.toString();
+
+    var resources = landingZoneManager.reader().listSharedResources(lzIdString);
+    assertThat(resources, hasSize(AggregateLandingZoneResourcesStep.deployedResourcesKeys.size()));
+
+    landingZoneManager.deleteResources(landingZoneId.toString());
+
+    // Immediate listing after deletion may return transient resources results.
+    await()
+        .atMost(Duration.ofSeconds(120))
+        .untilAsserted(
+            () -> {
+              var landingZoneResources =
+                  landingZoneManager.reader().listAllResources(landingZoneId.toString());
+              assertThat(landingZoneResources, empty());
+            });
   }
 
-
   // just a clone of the method in LandingZoneService
-  // but using the stairwayComponent directly means we don't have to fuss around with authentication,
+  // but using the stairwayComponent directly means we don't have to fuss around with
+  // authentication,
   // which brings in the requirement for a lot more mocking
   private FlightState retrieveFlightState(String jobId) {
     try {
@@ -121,5 +154,4 @@ public class CreateLandingZoneResourcesFlightIntegrationTest extends LandingZone
       throw new InternalStairwayException(stairwayEx);
     }
   }
-
 }

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
@@ -33,15 +33,15 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Tag("integration")
 @ActiveProfiles("test")
-@TestPropertySource("classpath:integration_azure_env.properties")
+@PropertySource(value = "classpath:integration_azure_env.properties", ignoreResourceNotFound = true)
 @ExtendWith(SpringExtension.class)
 @SpringBootTest()
 @SpringBootApplication(

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
@@ -33,15 +33,15 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.PropertySource;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Tag("integration")
 @ActiveProfiles("test")
-@PropertySource("classpath:integration_azure_env.properties")
+@TestPropertySource("classpath:integration_azure_env.properties")
 @ExtendWith(SpringExtension.class)
 @SpringBootTest()
 @SpringBootApplication(

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAccountStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAccountStepTest.java
@@ -124,6 +124,8 @@ class CreateStorageAccountStepTest extends BaseStepTest {
       String storageAccountId, String storageAccountName, String region, String resourceGroupName) {
     when(mockStorageAccount.id()).thenReturn(storageAccountId);
     when(mockStorageAccountDefinitionStagesWithCreate.create()).thenReturn(mockStorageAccount);
+    when(mockStorageAccountDefinitionStagesWithCreate.disableBlobPublicAccess())
+        .thenReturn(mockStorageAccountDefinitionStagesWithCreate);
     when(mockStorageAccountDefinitionStagesWithCreate.withTags(storageAccountTagsCaptor.capture()))
         .thenReturn(mockStorageAccountDefinitionStagesWithCreate);
     when(mockStorageAccountDefinitionStagesWithGroup.withExistingResourceGroup(resourceGroupName))

--- a/service/src/test/resources/application-test.yml
+++ b/service/src/test/resources/application-test.yml
@@ -3,15 +3,16 @@ landingzone:
 
   landingzone-database:
     initialize-on-start: true
-    password: landingzoneuser
+    password: landingzonepwd
     uri: jdbc:postgresql://127.0.0.1:5432/landingzone_db
-    username: landingzonepwd
+    username: landingzoneuser
 
   landingzone-stairway-database:
     initialize-on-start: true
     password: landingzonestairwaypwd
     uri: jdbc:postgresql://127.0.0.1:5432/landingzone_stairway_db
     username: landingzonestairwayuser
+
 
   stairway:
     cluster-name-suffix: workspace-stairway

--- a/service/src/test/resources/application-test.yml
+++ b/service/src/test/resources/application-test.yml
@@ -40,3 +40,9 @@ terra.common:
     in-kubernetes: false
   tracing:
     stackdriverExportEnabled: false
+
+workspace:
+  azure:
+    managedAppClientId: ${AZURE_PUBLISHER_CLIENT_ID}
+    managedAppClientSecret: ${AZURE_PUBLISHER_CLIENT_SECRET}
+    managedAppTenantId: ${AZURE_PUBLISHER_TENANT_ID}


### PR DESCRIPTION
a clean re-application of the changes originally in [this PR](https://github.com/DataBiosphere/terra-landing-zone-service/pull/124)

In addition, this cleans up the azure config setup, so that the spring based `LandingZoneAzureConfiguration` and the existing `AzureIntegrationUtils` used in tests look for the same properties.

[WOR-995](https://broadworkbench.atlassian.net/browse/WOR-995)

This is to add integration tests for the new stairway code path to create landing zone resources (CreateLandingZoneResourcesFlight).

I attempted to put these in the testharness project, but in the end it required more resources that were in the primary service project, so I abandoned that idea
This doesn't test creating the entire landing zone. The existing integration tests don't cover this, and it would require quite a bit more setup than we currently have (I tried it 😞 ).
These tests take a long time to run. This isn't really any different than the existing ones. It's just that the resources take a while to deploy.


[WOR-995]: https://broadworkbench.atlassian.net/browse/WOR-995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ