### PR TITLE
WOR-1028 Ship Azure AKS logs directly to centralized storage

### DIFF
--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/ProtectedDataStepsDefinitionProvider.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/ProtectedDataStepsDefinitionProvider.java
@@ -6,6 +6,7 @@ import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
 import bio.terra.landingzone.stairway.flight.create.resource.step.ConnectLongTermLogStorageStep;
+import bio.terra.landingzone.stairway.flight.create.resource.step.CreateAksLogSettingsStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateSentinelRunPlaybookAutomationRule;
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateSentinelStep;
 import bio.terra.landingzone.stairway.flight.utils.ProtectedDataAzureStorageHelper;
@@ -50,6 +51,15 @@ public class ProtectedDataStepsDefinitionProvider extends CromwellStepsDefinitio
     protectedDataSteps.add(
         Pair.of(
             new CreateSentinelRunPlaybookAutomationRule(
+                armManagers,
+                parametersResolver,
+                resourceNameGenerator,
+                landingZoneProtectedDataConfiguration),
+            RetryRules.cloud()));
+
+    protectedDataSteps.add(
+        Pair.of(
+            new CreateAksLogSettingsStep(
                 armManagers,
                 parametersResolver,
                 resourceNameGenerator,

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksLogSettingsStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksLogSettingsStep.java
@@ -1,0 +1,115 @@
+package bio.terra.landingzone.stairway.flight.create.resource.step;
+
+import static java.util.Map.entry;
+
+import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfiguration;
+import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
+import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
+import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
+import bio.terra.landingzone.stairway.flight.exception.MissingRequiredFieldsException;
+import bio.terra.stairway.FlightContext;
+import com.azure.resourcemanager.monitor.models.DiagnosticSetting;
+import com.azure.resourcemanager.resources.models.ResourceGroup;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CreateAksLogSettingsStep extends BaseResourceCreateStep {
+  private static final Logger logger = LoggerFactory.getLogger(CreateAksLogSettingsStep.class);
+
+  private static final int RETENTION_DAYS = 365;
+  private static final Map<String, Integer> AKS_LOGS_TO_CAPTURE =
+      Map.ofEntries(
+          entry("kube-apiserver", RETENTION_DAYS),
+          entry("kube-audit", RETENTION_DAYS),
+          entry("kube-audit-admin", RETENTION_DAYS),
+          entry("kube-controller-manager", RETENTION_DAYS),
+          entry("kube-scheduler", RETENTION_DAYS),
+          entry("cluster-autoscaler", RETENTION_DAYS),
+          entry("cloud-controller-manager", RETENTION_DAYS),
+          entry("guard", RETENTION_DAYS),
+          entry("csi-azuredisk-controller", RETENTION_DAYS),
+          entry("csi-azurefile-controller", RETENTION_DAYS),
+          entry("csi-snapshot-controller", RETENTION_DAYS));
+  private static final Map<String, Integer> AKS_METRICS_TO_CAPTURE =
+      Map.ofEntries(entry("AllMetrics", RETENTION_DAYS));
+
+  private final LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration;
+
+  public CreateAksLogSettingsStep(
+      ArmManagers armManagers,
+      ParametersResolver parametersResolver,
+      ResourceNameGenerator resourceNameGenerator,
+      LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration) {
+    super(armManagers, parametersResolver, resourceNameGenerator);
+    this.landingZoneProtectedDataConfiguration = landingZoneProtectedDataConfiguration;
+  }
+
+  @Override
+  protected void createResource(FlightContext context, ArmManagers armManagers) {
+    var aksId = getParameterOrThrow(context.getWorkingMap(), CreateAksStep.AKS_ID, String.class);
+
+    ResourceGroup resourceGroup =
+        armManagers.azureResourceManager().resourceGroups().getByName(getMRGName(context));
+    String lzRegion = resourceGroup.region().name();
+    if (!landingZoneProtectedDataConfiguration
+        .getLongTermStorageAccountIds()
+        .containsKey(lzRegion)) {
+      throw new MissingRequiredFieldsException(
+          "No matching long term storage account for region " + lzRegion);
+    }
+    // get long-term storage account based on region
+    var storageAccountId =
+        landingZoneProtectedDataConfiguration.getLongTermStorageAccountIds().get(lzRegion);
+    var aksLogSettingsName =
+        resourceNameGenerator.nextName(ResourceNameGenerator.MAX_DIAGNOSTIC_SETTING_NAME_LENGTH);
+    var aksDiagnosticSettingsConfiguration =
+        armManagers
+            .monitorManager()
+            .diagnosticSettings()
+            .define(aksLogSettingsName)
+            .withResource(aksId)
+            .withStorageAccount(storageAccountId);
+    aksDiagnosticSettingsConfiguration = setupLogConfiguration(aksDiagnosticSettingsConfiguration);
+    aksDiagnosticSettingsConfiguration =
+        setupMetricsConfiguration(aksDiagnosticSettingsConfiguration);
+
+    var aksDiagnosticSettings = aksDiagnosticSettingsConfiguration.create();
+    logger.info(
+        RESOURCE_CREATED, getResourceType(), aksDiagnosticSettings.id(), getMRGName(context));
+  }
+
+  private DiagnosticSetting.DefinitionStages.WithCreate setupLogConfiguration(
+      DiagnosticSetting.DefinitionStages.WithCreate aksPartiallySetup) {
+    for (Map.Entry<String, Integer> pair : AKS_LOGS_TO_CAPTURE.entrySet()) {
+      aksPartiallySetup = aksPartiallySetup.withLog(pair.getKey(), pair.getValue());
+    }
+    return aksPartiallySetup;
+  }
+
+  private DiagnosticSetting.DefinitionStages.WithCreate setupMetricsConfiguration(
+      DiagnosticSetting.DefinitionStages.WithCreate aksPartiallySetup) {
+    for (Map.Entry<String, Integer> pair : AKS_METRICS_TO_CAPTURE.entrySet()) {
+      aksPartiallySetup =
+          aksPartiallySetup.withMetric(pair.getKey(), Duration.ofSeconds(300), pair.getValue());
+    }
+    return aksPartiallySetup;
+  }
+
+  @Override
+  protected void deleteResource(String resourceId) {
+    // do nothing
+  }
+
+  @Override
+  protected String getResourceType() {
+    return "AksLogSettings";
+  }
+
+  @Override
+  protected Optional<String> getResourceId(FlightContext context) {
+    return Optional.empty();
+  }
+}

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksLogSettingsStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksLogSettingsStepTest.java
@@ -1,0 +1,208 @@
+package bio.terra.landingzone.stairway.flight.create.resource.step;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfiguration;
+import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
+import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
+import bio.terra.landingzone.stairway.flight.FlightTestUtils;
+import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.exception.MissingRequiredFieldsException;
+import bio.terra.profile.model.ProfileModel;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepStatus;
+import com.azure.resourcemanager.monitor.MonitorManager;
+import com.azure.resourcemanager.monitor.models.DiagnosticSetting;
+import com.azure.resourcemanager.monitor.models.DiagnosticSettings;
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("unit")
+public class CreateAksLogSettingsStepTest extends BaseStepTest {
+  @Mock private LandingZoneProtectedDataConfiguration mockLandingZoneProtectedDataConfiguration;
+  @Mock private MonitorManager mockMonitorManager;
+  @Mock private DiagnosticSettings mockDiagnosticSettings;
+  @Mock private DiagnosticSetting.DefinitionStages.Blank mockDefinitionStagesBlank;
+
+  @Mock
+  private DiagnosticSetting.DefinitionStages.WithDiagnosticLogRecipient
+      mockDefinitionStagesDiagnosticLogRecipient;
+
+  @Mock private DiagnosticSetting.DefinitionStages.WithCreate mockDefinitionStagesCreate;
+  @Mock private DiagnosticSetting mockDiagnosticSetting;
+
+  @Captor private ArgumentCaptor<String> aksDiagnosticSettingsNameCaptor;
+  @Captor private ArgumentCaptor<String> aksDiagnosticSettingsResourceIdCaptor;
+  @Captor private ArgumentCaptor<String> aksDiagnosticSettingsStorageAccountIdCaptor;
+  @Captor private ArgumentCaptor<String> aksLogNameCaptor;
+  @Captor private ArgumentCaptor<Integer> aksLogRetentionCaptor;
+  @Captor private ArgumentCaptor<String> aksMetricNameCaptor;
+  @Captor private ArgumentCaptor<Duration> aksMetricGranularityCaptor;
+  @Captor private ArgumentCaptor<Integer> aksMetricRetentionCaptor;
+
+  private CreateAksLogSettingsStep createAksLogSettingsStep;
+
+  @BeforeEach
+  void setup() {
+    createAksLogSettingsStep =
+        new CreateAksLogSettingsStep(
+            mockArmManagers,
+            mockParametersResolver,
+            mockResourceNameGenerator,
+            mockLandingZoneProtectedDataConfiguration);
+  }
+
+  @Test
+  void doStepSuccess() throws InterruptedException {
+    final String aksDiagnosticSettingName = "aksDiagnosticSettingName";
+    final String aksResourceId = "aksId";
+    final Map<String, String> storageAccountIds = Map.of("eastus", "ltsAccountEastUs");
+
+    TargetManagedResourceGroup mrg = ResourceStepFixture.createDefaultMrg();
+    when(mockResourceNameGenerator.nextName(
+            ResourceNameGenerator.MAX_DIAGNOSTIC_SETTING_NAME_LENGTH))
+        .thenReturn(aksDiagnosticSettingName);
+    when(mockLandingZoneProtectedDataConfiguration.getLongTermStorageAccountIds())
+        .thenReturn(storageAccountIds);
+
+    setupFlightContext(
+        mockFlightContext,
+        Map.of(
+            LandingZoneFlightMapKeys.BILLING_PROFILE,
+            new ProfileModel().id(UUID.randomUUID()),
+            LandingZoneFlightMapKeys.LANDING_ZONE_ID,
+            LANDING_ZONE_ID),
+        Map.of(
+            CreateAksStep.AKS_ID, aksResourceId, GetManagedResourceGroupInfo.TARGET_MRG_KEY, mrg));
+    setupArmManagersForDoStep();
+
+    var stepResult = createAksLogSettingsStep.doStep(mockFlightContext);
+
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(mockDefinitionStagesCreate, times(1)).create();
+    verifyNoMoreInteractions(mockDefinitionStagesCreate);
+    assertThat(aksDiagnosticSettingsNameCaptor.getValue(), equalTo(aksDiagnosticSettingName));
+    assertThat(aksDiagnosticSettingsResourceIdCaptor.getValue(), equalTo(aksResourceId));
+    assertThat(
+        aksDiagnosticSettingsStorageAccountIdCaptor.getValue(),
+        equalTo(storageAccountIds.get("eastus")));
+    verifyDiagnosticConfiguration();
+  }
+
+  @Test
+  void doStepLongTermStorageAccountNotFoundThrowsException() {
+    final String aksResourceId = "aksId";
+    final Map<String, String> storageAccountIds = Map.of("NOT_MATCHING_REGION", "ltsAccountEastUs");
+
+    TargetManagedResourceGroup mrg = ResourceStepFixture.createDefaultMrg();
+    when(mockLandingZoneProtectedDataConfiguration.getLongTermStorageAccountIds())
+        .thenReturn(storageAccountIds);
+
+    setupFlightContext(
+        mockFlightContext,
+        Map.of(
+            LandingZoneFlightMapKeys.BILLING_PROFILE,
+            new ProfileModel().id(UUID.randomUUID()),
+            LandingZoneFlightMapKeys.LANDING_ZONE_ID,
+            LANDING_ZONE_ID),
+        Map.of(
+            CreateAksStep.AKS_ID, aksResourceId, GetManagedResourceGroupInfo.TARGET_MRG_KEY, mrg));
+
+    assertThrows(
+        MissingRequiredFieldsException.class,
+        () -> createAksLogSettingsStep.doStep(mockFlightContext));
+  }
+
+  @ParameterizedTest
+  @MethodSource("inputParameterProvider")
+  void doStepMissingInputParameterThrowsException(Map<String, Object> inputParameters) {
+    FlightMap flightMapInputParameters =
+        FlightTestUtils.prepareFlightInputParameters(inputParameters);
+    when(mockFlightContext.getInputParameters()).thenReturn(flightMapInputParameters);
+
+    assertThrows(
+        MissingRequiredFieldsException.class,
+        () -> createAksLogSettingsStep.doStep(mockFlightContext));
+  }
+
+  @ParameterizedTest
+  @MethodSource("workingParametersProvider")
+  void doStepMissingWorkingParameterThrowsException(Map<String, Object> workingParameters) {
+    FlightMap flightMapInputParameters =
+        FlightTestUtils.prepareFlightInputParameters(
+            Map.of(
+                LandingZoneFlightMapKeys.BILLING_PROFILE,
+                new ProfileModel().id(UUID.randomUUID()),
+                LandingZoneFlightMapKeys.LANDING_ZONE_ID,
+                LANDING_ZONE_ID));
+    FlightMap flightMapWorkingParameters =
+        FlightTestUtils.prepareFlightWorkingParameters(workingParameters);
+    when(mockFlightContext.getInputParameters()).thenReturn(flightMapInputParameters);
+    when(mockFlightContext.getWorkingMap()).thenReturn(flightMapWorkingParameters);
+
+    assertThrows(
+        MissingRequiredFieldsException.class,
+        () -> createAksLogSettingsStep.doStep(mockFlightContext));
+  }
+
+  private void setupArmManagersForDoStep() {
+    when(mockDiagnosticSetting.id()).thenReturn("aksDiagnosticSettingId");
+    when(mockDefinitionStagesCreate.create()).thenReturn(mockDiagnosticSetting);
+    when(mockDefinitionStagesCreate.withMetric(
+            aksMetricNameCaptor.capture(),
+            aksMetricGranularityCaptor.capture(),
+            aksMetricRetentionCaptor.capture()))
+        .thenReturn(mockDefinitionStagesCreate);
+    when(mockDefinitionStagesCreate.withLog(
+            aksLogNameCaptor.capture(), aksLogRetentionCaptor.capture()))
+        .thenReturn(mockDefinitionStagesCreate);
+    when(mockDefinitionStagesDiagnosticLogRecipient.withStorageAccount(
+            aksDiagnosticSettingsStorageAccountIdCaptor.capture()))
+        .thenReturn(mockDefinitionStagesCreate);
+    when(mockDefinitionStagesBlank.withResource(aksDiagnosticSettingsResourceIdCaptor.capture()))
+        .thenReturn(mockDefinitionStagesDiagnosticLogRecipient);
+    when(mockDiagnosticSettings.define(aksDiagnosticSettingsNameCaptor.capture()))
+        .thenReturn(mockDefinitionStagesBlank);
+    when(mockMonitorManager.diagnosticSettings()).thenReturn(mockDiagnosticSettings);
+    when(mockArmManagers.monitorManager()).thenReturn(mockMonitorManager);
+  }
+
+  private void verifyDiagnosticConfiguration() {
+    int numberOfLogsToCapture = 11;
+    int numberOfMetricToCapture = 1;
+    assertThat(aksLogNameCaptor.getAllValues().size(), equalTo(numberOfLogsToCapture));
+    assertThat(aksLogRetentionCaptor.getAllValues().size(), equalTo(numberOfLogsToCapture));
+    assertThat(aksMetricNameCaptor.getAllValues().size(), equalTo(numberOfMetricToCapture));
+    assertThat(aksMetricGranularityCaptor.getAllValues().size(), equalTo(numberOfMetricToCapture));
+    assertThat(aksMetricRetentionCaptor.getAllValues().size(), equalTo(numberOfMetricToCapture));
+  }
+
+  private static Stream<Arguments> workingParametersProvider() {
+    return Stream.of(
+        Arguments.of(Map.of(CreateAksStep.AKS_ID, "aksId")),
+        Arguments.of(
+            Map.of(
+                GetManagedResourceGroupInfo.TARGET_MRG_KEY,
+                ResourceStepFixture.createDefaultMrg())));
+  }
+}

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/ResourceStepFixture.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/ResourceStepFixture.java
@@ -8,7 +8,7 @@ public class ResourceStepFixture {
   private ResourceStepFixture() {}
 
   public static TargetManagedResourceGroup createDefaultMrg() {
-    return new TargetManagedResourceGroup("mgrName", "mrgRegion");
+    return new TargetManagedResourceGroup("mgrName", "eastus");
   }
 
   public static ProfileModel createDefaultProfileModel() {


### PR DESCRIPTION
This PR adds configuration to AKS in LZ to ship its logs into long term storage account.