### PR TITLE
[WOR-1036] Run dependabot weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
   # Enable version updates for Gradle
   - package-ecosystem: "gradle"
     directory: "/"
+    open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
       time: "06:00"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,11 +18,3 @@ updates:
     ignore:
       - dependency-name: "org.springframework.boot:spring-boot-gradle-plugin"
         update-types: ["version-update:semver-major"]
-      - dependency-name: "com.azure.resourcemanager:azure-resourcemanager-containerinstance"
-        update-types: [ "version-update:semver-minor" ]
-      - dependency-name: "com.azure.resourcemanager:azure-resourcemanager-monitor"
-        update-types: [ "version-update:semver-minor" ]
-      - dependency-name: "com.azure.resourcemanager:azure-resourcemanager"
-        update-types: [ "version-update:semver-minor" ]
-      - dependency-name: "org.springframework.boot-spring-boot-starter-data-jdbc"
-        update-types: [ "version-update:semver-patch" ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,9 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      time: "06:00"
+      timezone: "America/New_York"
     target-branch: "main"
     reviewers:
       - "@DataBiosphere/broadworkspaces"
@@ -16,4 +18,3 @@ updates:
     ignore:
       - dependency-name: "org.springframework.boot:spring-boot-gradle-plugin"
         update-types: ["version-update:semver-major"]
-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,11 @@ updates:
     ignore:
       - dependency-name: "org.springframework.boot:spring-boot-gradle-plugin"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "com.azure.resourcemanager:azure-resourcemanager-containerinstance"
+        update-types: [ "version-update:semver-minor" ]
+      - dependency-name: "com.azure.resourcemanager:azure-resourcemanager-monitor"
+        update-types: [ "version-update:semver-minor" ]
+      - dependency-name: "com.azure.resourcemanager:azure-resourcemanager"
+        update-types: [ "version-update:semver-minor" ]
+      - dependency-name: "org.springframework.boot-spring-boot-starter-data-jdbc"
+        update-types: [ "version-update:semver-patch" ]


### PR DESCRIPTION
Dependabot PRs are becoming noisy to deal with on a daily basis. This shifts the updates to a weekly cadence. 

NOTE:
We had discussed limiting the updates for some of our noisier libs. I grepped through the git history and gave it a try with this [commit](https://github.com/DataBiosphere/terra-landing-zone-service/pull/140/commits/f1979afae0bfc0bcead0e5c7f446f4f4c95ef831). I think we should try reducing the cadence to weekly first, before silencing the noisier offenders.