### PR TITLE
WOR-1045 Potential LZ duplicate resources when Stairway recovers flight after failure

### DIFF
--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/CromwellStepsDefinitionProvider.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/CromwellStepsDefinitionProvider.java
@@ -3,9 +3,9 @@ package bio.terra.landingzone.stairway.flight;
 import bio.terra.landingzone.common.utils.RetryRules;
 import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfiguration;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
 import bio.terra.landingzone.library.landingzones.definition.factories.validation.InputParametersValidationFactory;
+import bio.terra.landingzone.stairway.flight.create.resource.step.BaseResourceCreateStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateAksStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateAppInsightsStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateBatchAccountStep;
@@ -37,7 +37,7 @@ public class CromwellStepsDefinitionProvider implements StepsDefinitionProvider 
   public List<Pair<Step, RetryRule>> get(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator,
+      ResourceNameProvider resourceNameProvider,
       LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration) {
     /*
      * ~ - depends on
@@ -66,63 +66,68 @@ public class CromwellStepsDefinitionProvider implements StepsDefinitionProvider 
             RetryRules.shortExponential()),
         Pair.of(new GetManagedResourceGroupInfo(armManagers), RetryRules.cloud()),
         Pair.of(
-            new CreateVnetStep(armManagers, parametersResolver, resourceNameGenerator),
+            new CreateVnetStep(armManagers, parametersResolver, resourceNameProvider),
             RetryRules.cloud()),
         Pair.of(
             new CreateLogAnalyticsWorkspaceStep(
-                armManagers, parametersResolver, resourceNameGenerator),
+                armManagers, parametersResolver, resourceNameProvider),
             RetryRules.cloud()),
         Pair.of(
-            new CreatePostgresqlDNSStep(armManagers, parametersResolver, resourceNameGenerator),
+            new CreatePostgresqlDNSStep(armManagers, parametersResolver, resourceNameProvider),
             RetryRules.cloud()),
         Pair.of(
-            new CreateVirtualNetworkLinkStep(
-                armManagers, parametersResolver, resourceNameGenerator),
+            new CreateVirtualNetworkLinkStep(armManagers, parametersResolver, resourceNameProvider),
             RetryRules.cloud()),
         Pair.of(
             new CreateLandingZoneIdentityStep(
-                armManagers, parametersResolver, resourceNameGenerator),
+                armManagers, parametersResolver, resourceNameProvider),
             RetryRules.cloud()),
         Pair.of(
-            new CreatePostgresqlDbStep(armManagers, parametersResolver, resourceNameGenerator),
+            new CreatePostgresqlDbStep(armManagers, parametersResolver, resourceNameProvider),
             RetryRules.cloud()),
         Pair.of(
-            new CreateStorageAccountStep(armManagers, parametersResolver, resourceNameGenerator),
+            new CreateStorageAccountStep(armManagers, parametersResolver, resourceNameProvider),
             RetryRules.cloud()),
         Pair.of(
-            new CreateBatchAccountStep(armManagers, parametersResolver, resourceNameGenerator),
+            new CreateBatchAccountStep(armManagers, parametersResolver, resourceNameProvider),
             RetryRules.cloud()),
         Pair.of(
             new CreateStorageAccountCorsRules(
-                armManagers, parametersResolver, resourceNameGenerator),
+                armManagers, parametersResolver, resourceNameProvider),
             RetryRules.cloud()),
         Pair.of(
             new CreateLogAnalyticsDataCollectionRulesStep(
-                armManagers, parametersResolver, resourceNameGenerator),
+                armManagers, parametersResolver, resourceNameProvider),
             RetryRules.cloud()),
         Pair.of(
-            new CreateAksStep(armManagers, parametersResolver, resourceNameGenerator),
+            new CreateAksStep(armManagers, parametersResolver, resourceNameProvider),
             RetryRules.cloud()),
         Pair.of(
             new CreateLandingZoneFederatedIdentityStep(
                 armManagers, new KubernetesClientProviderImpl()),
             RetryRules.cloud()),
         Pair.of(
-            new CreateRelayNamespaceStep(armManagers, parametersResolver, resourceNameGenerator),
+            new CreateRelayNamespaceStep(armManagers, parametersResolver, resourceNameProvider),
             RetryRules.cloud()),
         Pair.of(
             new CreateStorageAuditLogSettingsStep(
-                armManagers, parametersResolver, resourceNameGenerator),
+                armManagers, parametersResolver, resourceNameProvider),
             RetryRules.cloud()),
         Pair.of(
-            new CreateBatchLogSettingsStep(armManagers, parametersResolver, resourceNameGenerator),
+            new CreateBatchLogSettingsStep(armManagers, parametersResolver, resourceNameProvider),
             RetryRules.cloud()),
         Pair.of(
             new CreatePostgresLogSettingsStep(
-                armManagers, parametersResolver, resourceNameGenerator),
+                armManagers, parametersResolver, resourceNameProvider),
             RetryRules.cloud()),
         Pair.of(
-            new CreateAppInsightsStep(armManagers, parametersResolver, resourceNameGenerator),
+            new CreateAppInsightsStep(armManagers, parametersResolver, resourceNameProvider),
             RetryRules.cloud()));
+  }
+
+  private static Step registerStep(
+      BaseResourceCreateStep step, ResourceNameProvider resourceNameProvider) throws Exception {
+    resourceNameProvider.registerStep(step);
+    return step;
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/CromwellStepsDefinitionProvider.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/CromwellStepsDefinitionProvider.java
@@ -5,7 +5,6 @@ import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfi
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
 import bio.terra.landingzone.library.landingzones.definition.factories.validation.InputParametersValidationFactory;
-import bio.terra.landingzone.stairway.flight.create.resource.step.BaseResourceCreateStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateAksStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateAppInsightsStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateBatchAccountStep;
@@ -123,11 +122,5 @@ public class CromwellStepsDefinitionProvider implements StepsDefinitionProvider 
         Pair.of(
             new CreateAppInsightsStep(armManagers, parametersResolver, resourceNameProvider),
             RetryRules.cloud()));
-  }
-
-  private static Step registerStep(
-      BaseResourceCreateStep step, ResourceNameProvider resourceNameProvider) throws Exception {
-    resourceNameProvider.registerStep(step);
-    return step;
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/ProtectedDataStepsDefinitionProvider.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/ProtectedDataStepsDefinitionProvider.java
@@ -3,7 +3,6 @@ package bio.terra.landingzone.stairway.flight;
 import bio.terra.landingzone.common.utils.RetryRules;
 import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfiguration;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
 import bio.terra.landingzone.stairway.flight.create.resource.step.ConnectLongTermLogStorageStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateAksLogSettingsStep;
@@ -23,7 +22,7 @@ public class ProtectedDataStepsDefinitionProvider extends CromwellStepsDefinitio
   public List<Pair<Step, RetryRule>> get(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator,
+      ResourceNameProvider resourceNameProvider,
       LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration) {
     // inherit all cromwell steps and define specific below
     var protectedDataSteps =
@@ -31,7 +30,7 @@ public class ProtectedDataStepsDefinitionProvider extends CromwellStepsDefinitio
             super.get(
                 armManagers,
                 parametersResolver,
-                resourceNameGenerator,
+                resourceNameProvider,
                 landingZoneProtectedDataConfiguration));
 
     protectedDataSteps.add(
@@ -39,7 +38,7 @@ public class ProtectedDataStepsDefinitionProvider extends CromwellStepsDefinitio
             new ConnectLongTermLogStorageStep(
                 armManagers,
                 parametersResolver,
-                resourceNameGenerator,
+                resourceNameProvider,
                 new ProtectedDataAzureStorageHelper(armManagers),
                 landingZoneProtectedDataConfiguration.getLongTermStorageTableNames(),
                 landingZoneProtectedDataConfiguration.getLongTermStorageAccountIds()),
@@ -47,7 +46,7 @@ public class ProtectedDataStepsDefinitionProvider extends CromwellStepsDefinitio
 
     protectedDataSteps.add(
         Pair.of(
-            new CreateSentinelStep(armManagers, parametersResolver, resourceNameGenerator),
+            new CreateSentinelStep(armManagers, parametersResolver, resourceNameProvider),
             RetryRules.cloud()));
 
     protectedDataSteps.add(
@@ -55,7 +54,7 @@ public class ProtectedDataStepsDefinitionProvider extends CromwellStepsDefinitio
             new CreateSentinelRunPlaybookAutomationRule(
                 armManagers,
                 parametersResolver,
-                resourceNameGenerator,
+                resourceNameProvider,
                 landingZoneProtectedDataConfiguration),
             RetryRules.cloud()));
 
@@ -64,7 +63,7 @@ public class ProtectedDataStepsDefinitionProvider extends CromwellStepsDefinitio
             new CreateSentinelAlertRulesStep(
                 armManagers,
                 parametersResolver,
-                resourceNameGenerator,
+                resourceNameProvider,
                 new AlertRulesHelper(armManagers.securityInsightsManager()),
                 landingZoneProtectedDataConfiguration),
             RetryRules.cloud()));
@@ -73,7 +72,7 @@ public class ProtectedDataStepsDefinitionProvider extends CromwellStepsDefinitio
             new CreateAksLogSettingsStep(
                 armManagers,
                 parametersResolver,
-                resourceNameGenerator,
+                resourceNameProvider,
                 landingZoneProtectedDataConfiguration),
             RetryRules.cloud()));
 

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/ResourceNameProvider.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/ResourceNameProvider.java
@@ -7,15 +7,27 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-/** Provides name for a resource during LZ resource creation flight. */
+/**
+ * Provides name for a resource during LZ resource creation flight.
+ *
+ * <p>Each flight's step creates a resource or resources which require a unique name. Step should
+ * register itself in the ResourceNameProvider to be able to request a name(s) from it. All steps
+ * which inherit BaseResourceCreateStep are registered by default. Name generation is based on
+ * requirements provided by a step. Each step should uniquely identify resource(s) which would be
+ * created. For doing this it provides requirements for name generation. Requirements are
+ * represented by a pair of unique name (resourceType) which helps identify a resource for which a
+ * new name will be generated and maximum length of requested name. Some steps might claim multiple
+ * names (like CreateAksStep). In this case resourceType represents a main resource and is used
+ * together with some other unique string to represent an auxiliary resource.
+ */
 public class ResourceNameProvider {
   private final ResourceNameGenerator resourceNameGenerator;
   // key is resource type, value is corresponding name
-  private final Map<String, String> resourceNames;
+  private final Map<String, String> resourceTypeNames;
 
   public ResourceNameProvider(UUID landingZoneId) {
     this.resourceNameGenerator = new ResourceNameGenerator(landingZoneId.toString());
-    resourceNames = new HashMap<>();
+    resourceTypeNames = new HashMap<>();
   }
 
   /** Register LZ flight step for resource name generation. */
@@ -23,23 +35,24 @@ public class ResourceNameProvider {
     var resourceNameRequirements = step.getResourceNameRequirements();
     resourceNameRequirements.forEach(
         nameRequirements -> {
-          if (resourceNames.containsKey(nameRequirements.resource())) {
+          if (resourceTypeNames.containsKey(nameRequirements.resourceType())) {
             throw new ResourceNameGenerationException(
                 String.format(
-                    "Step with resource %s is already registered for name generation.",
-                    nameRequirements.resource()));
+                    "Step with resource type '%s' is already registered for name generation.",
+                    nameRequirements.resourceType()));
           }
-          resourceNames.put(
-              nameRequirements.resource(),
+          resourceTypeNames.put(
+              nameRequirements.resourceType(),
               resourceNameGenerator.nextName(nameRequirements.maxNameLength()));
         });
   }
 
-  public String getName(String resource) {
-    if (resourceNames.containsKey(resource)) {
-      return resourceNames.get(resource);
+  public String getName(String resourceType) {
+    if (resourceTypeNames.containsKey(resourceType)) {
+      return resourceTypeNames.get(resourceType);
     }
     throw new ResourceNameGenerationException(
-        String.format("Step with resource %s is not registered for name generation.", resource));
+        String.format(
+            "Step with resource type '%s' is not registered for name generation.", resourceType));
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/ResourceNameProvider.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/ResourceNameProvider.java
@@ -1,0 +1,45 @@
+package bio.terra.landingzone.stairway.flight;
+
+import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
+import bio.terra.landingzone.stairway.flight.create.resource.step.BaseResourceCreateStep;
+import bio.terra.landingzone.stairway.flight.exception.ResourceNameGenerationException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/** Provides name for a resource during LZ resource creation flight. */
+public class ResourceNameProvider {
+  private final ResourceNameGenerator resourceNameGenerator;
+  // key is resource type, value is corresponding name
+  private final Map<String, String> resourceNames;
+
+  public ResourceNameProvider(UUID landingZoneId) {
+    this.resourceNameGenerator = new ResourceNameGenerator(landingZoneId.toString());
+    resourceNames = new HashMap<>();
+  }
+
+  /** Register LZ flight step for resource name generation. */
+  public void registerStep(BaseResourceCreateStep step) {
+    var resourceNameRequirements = step.getResourceNameRequirements();
+    resourceNameRequirements.forEach(
+        nameRequirements -> {
+          if (resourceNames.containsKey(nameRequirements.resource())) {
+            throw new ResourceNameGenerationException(
+                String.format(
+                    "Step with resource %s is already registered for name generation.",
+                    nameRequirements.resource()));
+          }
+          resourceNames.put(
+              nameRequirements.resource(),
+              resourceNameGenerator.nextName(nameRequirements.maxNameLength()));
+        });
+  }
+
+  public String getName(String resource) {
+    if (resourceNames.containsKey(resource)) {
+      return resourceNames.get(resource);
+    }
+    throw new ResourceNameGenerationException(
+        String.format("Step with resource %s is not registered for name generation.", resource));
+  }
+}

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/ResourceNameRequirements.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/ResourceNameRequirements.java
@@ -1,0 +1,3 @@
+package bio.terra.landingzone.stairway.flight;
+
+public record ResourceNameRequirements(String resource, int maxNameLength) {}

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/ResourceNameRequirements.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/ResourceNameRequirements.java
@@ -1,3 +1,11 @@
 package bio.terra.landingzone.stairway.flight;
 
-public record ResourceNameRequirements(String resource, int maxNameLength) {}
+/**
+ * Represents a requirements for resource name generation during LZ resource creation flight. This
+ * can be extended in future in case we have requirements for a minimal length of a name or anything
+ * else.
+ *
+ * @param resourceType Uniquely identify resource for which name should be generated.
+ * @param maxNameLength The maximum length of a name.
+ */
+public record ResourceNameRequirements(String resourceType, int maxNameLength) {}

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/StepsDefinitionProvider.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/StepsDefinitionProvider.java
@@ -2,7 +2,6 @@ package bio.terra.landingzone.stairway.flight;
 
 import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfiguration;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
 import bio.terra.stairway.RetryRule;
 import bio.terra.stairway.Step;
@@ -11,21 +10,21 @@ import org.apache.commons.lang3.tuple.Pair;
 
 public interface StepsDefinitionProvider {
   /**
-   * Returns list of required together with corresponding retry rule. Each step creates one specific
-   * landing zone resource. Order of steps matters. If a resource1 has dependency on another
-   * resource2 then resource1 should be deployed first and save its id or another required
-   * information for resource2 (using flight working map). So, step for resource1 should go first in
-   * the list definition.
+   * Returns list of required steps for LZ flight together with corresponding retry rule. Each step
+   * creates one specific landing zone resource. Order of steps matters. If a resource1 has
+   * dependency on another resource2 then resource1 should be deployed first and save its id or
+   * another required information for resource2 (using flight working map). So, step for resource1
+   * should go first in the list definition.
    *
    * @param ArmManagers armManagers
    * @param ParametersResolver parametersResolver
-   * @param ResourceNameGenerator resourceNameGenerator
+   * @param ResourceNameProvider resourceNameProvider
    * @param LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration
    * @return List of pairs of steps and step's retry rule
    */
   List<Pair<Step, RetryRule>> get(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator,
+      ResourceNameProvider resourceNameProvider,
       LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration);
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlight.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlight.java
@@ -56,15 +56,15 @@ public class CreateLandingZoneResourcesFlight extends Flight {
     landingZoneProtectedDataConfiguration =
         flightBeanBag.getLandingZoneProtectedDataConfiguration();
 
+    var landingZoneId = getLandingZoneId(inputParameters, landingZoneRequest);
+    resourceNameProvider = new ResourceNameProvider(landingZoneId);
+
     stepsDefinitionProvider =
         LandingZoneStepsDefinitionProviderFactory.create(
             StepsDefinitionFactoryType.fromString(landingZoneRequest.definition()));
     armManagers = initializeArmManagers(inputParameters, flightBeanBag.getAzureConfiguration());
     parametersResolver =
         new ParametersResolver(landingZoneRequest.parameters(), LandingZoneDefaultParameters.get());
-
-    var landingZoneId = getLandingZoneId(inputParameters, landingZoneRequest);
-    resourceNameProvider = new ResourceNameProvider(landingZoneId);
 
     addCreateSteps();
   }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlight.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlight.java
@@ -5,7 +5,6 @@ import bio.terra.landingzone.common.utils.RetryRules;
 import bio.terra.landingzone.library.configuration.LandingZoneAzureConfiguration;
 import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfiguration;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
 import bio.terra.landingzone.library.landingzones.management.LandingZoneManager;
 import bio.terra.landingzone.model.LandingZoneTarget;
@@ -13,6 +12,7 @@ import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneRequest;
 import bio.terra.landingzone.stairway.flight.LandingZoneDefaultParameters;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
 import bio.terra.landingzone.stairway.flight.LandingZoneStepsDefinitionProviderFactory;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
 import bio.terra.landingzone.stairway.flight.StepsDefinitionFactoryType;
 import bio.terra.landingzone.stairway.flight.StepsDefinitionProvider;
 import bio.terra.landingzone.stairway.flight.create.resource.step.AggregateLandingZoneResourcesStep;
@@ -30,7 +30,7 @@ public class CreateLandingZoneResourcesFlight extends Flight {
   private final StepsDefinitionProvider stepsDefinitionProvider;
   private final LandingZoneRequest landingZoneRequest;
   private final ArmManagers armManagers;
-  private final ResourceNameGenerator resourceNameGenerator;
+  private final ResourceNameProvider resourceNameProvider;
   private final ParametersResolver parametersResolver;
   private final LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration;
 
@@ -56,15 +56,15 @@ public class CreateLandingZoneResourcesFlight extends Flight {
     landingZoneProtectedDataConfiguration =
         flightBeanBag.getLandingZoneProtectedDataConfiguration();
 
-    var landingZoneId = getLandingZoneId(inputParameters, landingZoneRequest);
-    resourceNameGenerator = new ResourceNameGenerator(landingZoneId.toString());
-
     stepsDefinitionProvider =
         LandingZoneStepsDefinitionProviderFactory.create(
             StepsDefinitionFactoryType.fromString(landingZoneRequest.definition()));
     armManagers = initializeArmManagers(inputParameters, flightBeanBag.getAzureConfiguration());
     parametersResolver =
         new ParametersResolver(landingZoneRequest.parameters(), LandingZoneDefaultParameters.get());
+
+    var landingZoneId = getLandingZoneId(inputParameters, landingZoneRequest);
+    resourceNameProvider = new ResourceNameProvider(landingZoneId);
 
     addCreateSteps();
   }
@@ -74,7 +74,7 @@ public class CreateLandingZoneResourcesFlight extends Flight {
         .get(
             armManagers,
             parametersResolver,
-            resourceNameGenerator,
+            resourceNameProvider,
             landingZoneProtectedDataConfiguration)
         .forEach(pair -> addStep(pair.getLeft(), pair.getRight()));
 

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/ConnectLongTermLogStorageStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/ConnectLongTermLogStorageStep.java
@@ -1,9 +1,10 @@
 package bio.terra.landingzone.stairway.flight.create.resource.step;
 
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
+import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.landingzone.stairway.flight.exception.LandingZoneCreateException;
 import bio.terra.landingzone.stairway.flight.exception.MissingRequiredFieldsException;
 import bio.terra.landingzone.stairway.flight.utils.ProtectedDataAzureStorageHelper;
@@ -31,11 +32,11 @@ public class ConnectLongTermLogStorageStep extends BaseResourceCreateStep {
   public ConnectLongTermLogStorageStep(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator,
+      ResourceNameProvider resourceNameProvider,
       ProtectedDataAzureStorageHelper storageHelper,
       List<String> tableNames,
       Map<String, String> longTermStorageAccountIds) {
-    super(armManagers, parametersResolver, resourceNameGenerator);
+    super(armManagers, parametersResolver, resourceNameProvider);
     this.tableNames = tableNames;
     this.storageHelper = storageHelper;
     this.longTermStorageAccountIds = longTermStorageAccountIds;
@@ -66,7 +67,7 @@ public class ConnectLongTermLogStorageStep extends BaseResourceCreateStep {
     }
 
     var destinationStorageAccountResourceId = longTermStorageAccountIds.get(lzRegion);
-    var exportName = resourceNameGenerator.nextName(MAX_DATA_EXPORT_NAME_LENGTH);
+    var exportName = resourceNameProvider.getName(getResourceType());
     var result =
         storageHelper.createLogAnalyticsDataExport(
             exportName,
@@ -101,5 +102,10 @@ public class ConnectLongTermLogStorageStep extends BaseResourceCreateStep {
   @Override
   protected Optional<String> getResourceId(FlightContext context) {
     return Optional.ofNullable(context.getWorkingMap().get(DATA_EXPORT_ID, String.class));
+  }
+
+  @Override
+  public List<ResourceNameRequirements> getResourceNameRequirements() {
+    return List.of(new ResourceNameRequirements(getResourceType(), MAX_DATA_EXPORT_NAME_LENGTH));
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksLogSettingsStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksLogSettingsStep.java
@@ -6,10 +6,13 @@ import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfi
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
+import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.landingzone.stairway.flight.exception.MissingRequiredFieldsException;
 import bio.terra.stairway.FlightContext;
 import com.azure.resourcemanager.monitor.models.DiagnosticSetting;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -42,9 +45,9 @@ public class CreateAksLogSettingsStep extends BaseResourceCreateStep {
   public CreateAksLogSettingsStep(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator,
+      ResourceNameProvider resourceNameProvider,
       LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration) {
-    super(armManagers, parametersResolver, resourceNameGenerator);
+    super(armManagers, parametersResolver, resourceNameProvider);
     this.landingZoneProtectedDataConfiguration = landingZoneProtectedDataConfiguration;
   }
 
@@ -62,8 +65,7 @@ public class CreateAksLogSettingsStep extends BaseResourceCreateStep {
     // get long-term storage account based on region
     var storageAccountId =
         landingZoneProtectedDataConfiguration.getLongTermStorageAccountIds().get(lzRegion);
-    var aksLogSettingsName =
-        resourceNameGenerator.nextName(ResourceNameGenerator.MAX_DIAGNOSTIC_SETTING_NAME_LENGTH);
+    var aksLogSettingsName = resourceNameProvider.getName(getResourceType());
     var aksDiagnosticSettingsConfiguration =
         armManagers
             .monitorManager()
@@ -111,5 +113,12 @@ public class CreateAksLogSettingsStep extends BaseResourceCreateStep {
   @Override
   protected Optional<String> getResourceId(FlightContext context) {
     return Optional.empty();
+  }
+
+  @Override
+  public List<ResourceNameRequirements> getResourceNameRequirements() {
+    return List.of(
+        new ResourceNameRequirements(
+            getResourceType(), ResourceNameGenerator.MAX_DIAGNOSTIC_SETTING_NAME_LENGTH));
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAppInsightsStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAppInsightsStep.java
@@ -6,8 +6,11 @@ import bio.terra.landingzone.library.landingzones.definition.factories.Parameter
 import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
 import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
+import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.stairway.FlightContext;
 import com.azure.resourcemanager.applicationinsights.models.ApplicationType;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -21,8 +24,8 @@ public class CreateAppInsightsStep extends BaseResourceCreateStep {
   public CreateAppInsightsStep(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator) {
-    super(armManagers, parametersResolver, resourceNameGenerator);
+      ResourceNameProvider resourceNameProvider) {
+    super(armManagers, parametersResolver, resourceNameProvider);
   }
 
   @Override
@@ -36,9 +39,7 @@ public class CreateAppInsightsStep extends BaseResourceCreateStep {
             CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_WORKSPACE_ID,
             String.class);
 
-    var appInsightsName =
-        resourceNameGenerator.nextName(
-            ResourceNameGenerator.MAX_APP_INSIGHTS_COMPONENT_NAME_LENGTH);
+    var appInsightsName = resourceNameProvider.getName(getResourceType());
     var appInsight =
         armManagers
             .applicationInsightsManager()
@@ -73,5 +74,12 @@ public class CreateAppInsightsStep extends BaseResourceCreateStep {
   @Override
   protected Optional<String> getResourceId(FlightContext context) {
     return Optional.ofNullable(context.getWorkingMap().get(APP_INSIGHT_ID, String.class));
+  }
+
+  @Override
+  public List<ResourceNameRequirements> getResourceNameRequirements() {
+    return List.of(
+        new ResourceNameRequirements(
+            getResourceType(), ResourceNameGenerator.MAX_APP_INSIGHTS_COMPONENT_NAME_LENGTH));
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateBatchAccountStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateBatchAccountStep.java
@@ -7,7 +7,10 @@ import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
 import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
+import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.stairway.FlightContext;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -22,8 +25,8 @@ public class CreateBatchAccountStep extends BaseResourceCreateStep {
   public CreateBatchAccountStep(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator) {
-    super(armManagers, parametersResolver, resourceNameGenerator);
+      ResourceNameProvider resourceNameProvider) {
+    super(armManagers, parametersResolver, resourceNameProvider);
   }
 
   @Override
@@ -32,8 +35,7 @@ public class CreateBatchAccountStep extends BaseResourceCreateStep {
         getParameterOrThrow(
             context.getInputParameters(), LandingZoneFlightMapKeys.LANDING_ZONE_ID, UUID.class);
 
-    String batchAccountName =
-        resourceNameGenerator.nextName(ResourceNameGenerator.MAX_BATCH_ACCOUNT_NAME_LENGTH);
+    String batchAccountName = resourceNameProvider.getName(getResourceType());
     var batch =
         armManagers
             .batchManager()
@@ -76,5 +78,12 @@ public class CreateBatchAccountStep extends BaseResourceCreateStep {
   @Override
   protected Optional<String> getResourceId(FlightContext context) {
     return Optional.ofNullable(context.getWorkingMap().get(BATCH_ACCOUNT_ID, String.class));
+  }
+
+  @Override
+  public List<ResourceNameRequirements> getResourceNameRequirements() {
+    return List.of(
+        new ResourceNameRequirements(
+            getResourceType(), ResourceNameGenerator.MAX_BATCH_ACCOUNT_NAME_LENGTH));
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateBatchLogSettingsStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateBatchLogSettingsStep.java
@@ -3,8 +3,11 @@ package bio.terra.landingzone.stairway.flight.create.resource.step;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
+import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.StepResult;
+import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,8 +18,8 @@ public class CreateBatchLogSettingsStep extends BaseResourceCreateStep {
   public CreateBatchLogSettingsStep(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator) {
-    super(armManagers, parametersResolver, resourceNameGenerator);
+      ResourceNameProvider resourceNameProvider) {
+    super(armManagers, parametersResolver, resourceNameProvider);
   }
 
   @Override
@@ -36,8 +39,7 @@ public class CreateBatchLogSettingsStep extends BaseResourceCreateStep {
             CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_WORKSPACE_ID,
             String.class);
 
-    var batchLogSettingsName =
-        resourceNameGenerator.nextName(ResourceNameGenerator.MAX_DIAGNOSTIC_SETTING_NAME_LENGTH);
+    var batchLogSettingsName = resourceNameProvider.getName(getResourceType());
     var batchLogSettings =
         armManagers
             .monitorManager()
@@ -65,5 +67,12 @@ public class CreateBatchLogSettingsStep extends BaseResourceCreateStep {
   @Override
   protected Optional<String> getResourceId(FlightContext context) {
     return Optional.empty();
+  }
+
+  @Override
+  public List<ResourceNameRequirements> getResourceNameRequirements() {
+    return List.of(
+        new ResourceNameRequirements(
+            getResourceType(), ResourceNameGenerator.MAX_DIAGNOSTIC_SETTING_NAME_LENGTH));
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateLandingZoneIdentityStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateLandingZoneIdentityStep.java
@@ -1,7 +1,5 @@
 package bio.terra.landingzone.stairway.flight.create.resource.step;
 
-import static bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator.UAMI_NAME_LENGTH;
-
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
@@ -9,7 +7,10 @@ import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
 import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
+import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.stairway.FlightContext;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -27,8 +28,8 @@ public class CreateLandingZoneIdentityStep extends BaseResourceCreateStep {
   public CreateLandingZoneIdentityStep(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator) {
-    super(armManagers, parametersResolver, resourceNameGenerator);
+      ResourceNameProvider resourceNameProvider) {
+    super(armManagers, parametersResolver, resourceNameProvider);
   }
 
   @Override
@@ -37,7 +38,7 @@ public class CreateLandingZoneIdentityStep extends BaseResourceCreateStep {
         getParameterOrThrow(
             context.getInputParameters(), LandingZoneFlightMapKeys.LANDING_ZONE_ID, UUID.class);
 
-    var identityName = resourceNameGenerator.nextName(UAMI_NAME_LENGTH);
+    var identityName = resourceNameProvider.getName(getResourceType());
 
     var uami =
         armManagers
@@ -84,5 +85,11 @@ public class CreateLandingZoneIdentityStep extends BaseResourceCreateStep {
   @Override
   protected Optional<String> getResourceId(FlightContext context) {
     return Optional.ofNullable(context.getWorkingMap().get(LANDING_ZONE_IDENTITY_ID, String.class));
+  }
+
+  @Override
+  public List<ResourceNameRequirements> getResourceNameRequirements() {
+    return List.of(
+        new ResourceNameRequirements(getResourceType(), ResourceNameGenerator.UAMI_NAME_LENGTH));
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateLogAnalyticsDataCollectionRulesStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateLogAnalyticsDataCollectionRulesStep.java
@@ -6,6 +6,8 @@ import bio.terra.landingzone.library.landingzones.definition.factories.Parameter
 import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
 import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
+import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
@@ -39,8 +41,8 @@ public class CreateLogAnalyticsDataCollectionRulesStep extends BaseResourceCreat
   public CreateLogAnalyticsDataCollectionRulesStep(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator) {
-    super(armManagers, parametersResolver, resourceNameGenerator);
+      ResourceNameProvider resourceNameProvider) {
+    super(armManagers, parametersResolver, resourceNameProvider);
   }
 
   @Override
@@ -84,8 +86,7 @@ public class CreateLogAnalyticsDataCollectionRulesStep extends BaseResourceCreat
             context.getWorkingMap(),
             CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_WORKSPACE_ID,
             String.class);
-    var dataCollectionRulesName =
-        resourceNameGenerator.nextName(ResourceNameGenerator.MAX_DATA_COLLECTION_RULE_NAME_LENGTH);
+    var dataCollectionRulesName = resourceNameProvider.getName(getResourceType());
     var dataCollectionRules =
         armManagers
             .monitorManager()
@@ -162,5 +163,12 @@ public class CreateLogAnalyticsDataCollectionRulesStep extends BaseResourceCreat
   @Override
   protected Optional<String> getResourceId(FlightContext context) {
     return Optional.empty();
+  }
+
+  @Override
+  public List<ResourceNameRequirements> getResourceNameRequirements() {
+    return List.of(
+        new ResourceNameRequirements(
+            getResourceType(), ResourceNameGenerator.MAX_DATA_COLLECTION_RULE_NAME_LENGTH));
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateLogAnalyticsWorkspaceStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateLogAnalyticsWorkspaceStep.java
@@ -9,10 +9,13 @@ import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
 import bio.terra.landingzone.library.landingzones.management.AzureResourceTypeUtils;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
+import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import com.azure.core.management.exception.ManagementException;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -30,8 +33,8 @@ public class CreateLogAnalyticsWorkspaceStep extends BaseResourceCreateStep {
   public CreateLogAnalyticsWorkspaceStep(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator) {
-    super(armManagers, parametersResolver, resourceNameGenerator);
+      ResourceNameProvider resourceNameProvider) {
+    super(armManagers, parametersResolver, resourceNameProvider);
   }
 
   @Override
@@ -89,9 +92,7 @@ public class CreateLogAnalyticsWorkspaceStep extends BaseResourceCreateStep {
     var landingZoneId =
         getParameterOrThrow(
             context.getInputParameters(), LandingZoneFlightMapKeys.LANDING_ZONE_ID, UUID.class);
-    var logAnalyticsName =
-        resourceNameGenerator.nextName(
-            ResourceNameGenerator.MAX_LOG_ANALYTICS_WORKSPACE_NAME_LENGTH);
+    var logAnalyticsName = resourceNameProvider.getName(getResourceType());
 
     var logAnalyticsWorkspace =
         armManagers
@@ -145,5 +146,12 @@ public class CreateLogAnalyticsWorkspaceStep extends BaseResourceCreateStep {
   protected Optional<String> getResourceId(FlightContext context) {
     return Optional.ofNullable(
         context.getWorkingMap().get(LOG_ANALYTICS_WORKSPACE_ID, String.class));
+  }
+
+  @Override
+  public List<ResourceNameRequirements> getResourceNameRequirements() {
+    return List.of(
+        new ResourceNameRequirements(
+            getResourceType(), ResourceNameGenerator.MAX_LOG_ANALYTICS_WORKSPACE_NAME_LENGTH));
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreatePostgresLogSettingsStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreatePostgresLogSettingsStep.java
@@ -3,8 +3,10 @@ package bio.terra.landingzone.stairway.flight.create.resource.step;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
+import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.stairway.FlightContext;
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,8 +17,8 @@ public class CreatePostgresLogSettingsStep extends BaseResourceCreateStep {
   public CreatePostgresLogSettingsStep(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator) {
-    super(armManagers, parametersResolver, resourceNameGenerator);
+      bio.terra.landingzone.stairway.flight.ResourceNameProvider resourceNameProvider) {
+    super(armManagers, parametersResolver, resourceNameProvider);
   }
 
   @Override
@@ -30,8 +32,7 @@ public class CreatePostgresLogSettingsStep extends BaseResourceCreateStep {
             CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_WORKSPACE_ID,
             String.class);
 
-    var postgresLogSettingsName =
-        resourceNameGenerator.nextName(ResourceNameGenerator.MAX_DIAGNOSTIC_SETTING_NAME_LENGTH);
+    var postgresLogSettingsName = resourceNameProvider.getName(getResourceType());
 
     var postgresLogSettings =
         armManagers
@@ -61,5 +62,12 @@ public class CreatePostgresLogSettingsStep extends BaseResourceCreateStep {
   @Override
   protected Optional<String> getResourceId(FlightContext context) {
     return Optional.empty();
+  }
+
+  @Override
+  public List<ResourceNameRequirements> getResourceNameRequirements() {
+    return List.of(
+        new ResourceNameRequirements(
+            getResourceType(), ResourceNameGenerator.MAX_DIAGNOSTIC_SETTING_NAME_LENGTH));
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreatePostgresqlDNSStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreatePostgresqlDNSStep.java
@@ -6,8 +6,10 @@ import bio.terra.landingzone.library.landingzones.definition.factories.Parameter
 import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
+import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.stairway.FlightContext;
-import com.azure.resourcemanager.postgresqlflexibleserver.models.*;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -23,8 +25,8 @@ public class CreatePostgresqlDNSStep extends BaseResourceCreateStep {
   public CreatePostgresqlDNSStep(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator) {
-    super(armManagers, parametersResolver, resourceNameGenerator);
+      ResourceNameProvider resourceNameProvider) {
+    super(armManagers, parametersResolver, resourceNameProvider);
   }
 
   @Override
@@ -33,8 +35,7 @@ public class CreatePostgresqlDNSStep extends BaseResourceCreateStep {
         getParameterOrThrow(
             context.getInputParameters(), LandingZoneFlightMapKeys.LANDING_ZONE_ID, UUID.class);
 
-    var dnsZoneName =
-        resourceNameGenerator.nextName(ResourceNameGenerator.MAX_PRIVATE_DNS_ZONE_NAME_LENGTH);
+    var dnsZoneName = resourceNameProvider.getName(getResourceType());
 
     var dns =
         armManagers
@@ -74,5 +75,12 @@ public class CreatePostgresqlDNSStep extends BaseResourceCreateStep {
   @Override
   protected Optional<String> getResourceId(FlightContext context) {
     return Optional.ofNullable(context.getWorkingMap().get(POSTGRESQL_DNS_ID, String.class));
+  }
+
+  @Override
+  public List<ResourceNameRequirements> getResourceNameRequirements() {
+    return List.of(
+        new ResourceNameRequirements(
+            getResourceType(), ResourceNameGenerator.MAX_PRIVATE_DNS_ZONE_NAME_LENGTH));
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreatePostgresqlDbStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreatePostgresqlDbStep.java
@@ -8,6 +8,8 @@ import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
 import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
+import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.stairway.FlightContext;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.postgresqlflexibleserver.models.ActiveDirectoryAuthEnum;
@@ -25,6 +27,7 @@ import com.azure.resourcemanager.postgresqlflexibleserver.models.ServerVersion;
 import com.azure.resourcemanager.postgresqlflexibleserver.models.Sku;
 import com.azure.resourcemanager.postgresqlflexibleserver.models.SkuTier;
 import com.azure.resourcemanager.postgresqlflexibleserver.models.Storage;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -40,14 +43,13 @@ public class CreatePostgresqlDbStep extends BaseResourceCreateStep {
   public CreatePostgresqlDbStep(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator) {
-    super(armManagers, parametersResolver, resourceNameGenerator);
+      ResourceNameProvider resourceNameProvider) {
+    super(armManagers, parametersResolver, resourceNameProvider);
   }
 
   @Override
   protected void createResource(FlightContext context, ArmManagers armManagers) {
-    var postgresName =
-        resourceNameGenerator.nextName(ResourceNameGenerator.MAX_POSTGRESQL_SERVER_NAME_LENGTH);
+    var postgresName = resourceNameProvider.getName(getResourceType());
 
     var postgres = createServer(context, armManagers, postgresName);
 
@@ -185,5 +187,12 @@ public class CreatePostgresqlDbStep extends BaseResourceCreateStep {
   @Override
   protected Optional<String> getResourceId(FlightContext context) {
     return Optional.ofNullable(context.getWorkingMap().get(POSTGRESQL_ID, String.class));
+  }
+
+  @Override
+  public List<ResourceNameRequirements> getResourceNameRequirements() {
+    return List.of(
+        new ResourceNameRequirements(
+            getResourceType(), ResourceNameGenerator.MAX_POSTGRESQL_SERVER_NAME_LENGTH));
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateRelayNamespaceStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateRelayNamespaceStep.java
@@ -7,7 +7,10 @@ import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
 import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
+import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.stairway.FlightContext;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -22,8 +25,8 @@ public class CreateRelayNamespaceStep extends BaseResourceCreateStep {
   public CreateRelayNamespaceStep(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator) {
-    super(armManagers, parametersResolver, resourceNameGenerator);
+      ResourceNameProvider resourceNameProvider) {
+    super(armManagers, parametersResolver, resourceNameProvider);
   }
 
   @Override
@@ -32,7 +35,7 @@ public class CreateRelayNamespaceStep extends BaseResourceCreateStep {
         getParameterOrThrow(
             context.getInputParameters(), LandingZoneFlightMapKeys.LANDING_ZONE_ID, UUID.class);
 
-    var relayName = resourceNameGenerator.nextName(ResourceNameGenerator.MAX_RELAY_NS_NAME_LENGTH);
+    var relayName = resourceNameProvider.getName(getResourceType());
     var relayNamespace =
         armManagers
             .relayManager()
@@ -75,5 +78,12 @@ public class CreateRelayNamespaceStep extends BaseResourceCreateStep {
   @Override
   protected Optional<String> getResourceId(FlightContext context) {
     return Optional.ofNullable(context.getWorkingMap().get(RELAY_NAMESPACE_ID, String.class));
+  }
+
+  @Override
+  public List<ResourceNameRequirements> getResourceNameRequirements() {
+    return List.of(
+        new ResourceNameRequirements(
+            getResourceType(), ResourceNameGenerator.MAX_RELAY_NS_NAME_LENGTH));
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelAlertRulesStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelAlertRulesStep.java
@@ -2,9 +2,10 @@ package bio.terra.landingzone.stairway.flight.create.resource.step;
 
 import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfiguration;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
+import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.landingzone.stairway.flight.exception.MissingRequiredFieldsException;
 import bio.terra.landingzone.stairway.flight.utils.AlertRulesHelper;
 import bio.terra.stairway.FlightContext;
@@ -13,6 +14,7 @@ import com.azure.resourcemanager.securityinsights.models.MLBehaviorAnalyticsAler
 import com.azure.resourcemanager.securityinsights.models.ScheduledAlertRule;
 import com.azure.resourcemanager.securityinsights.models.TriggerOperator;
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,10 +27,10 @@ public class CreateSentinelAlertRulesStep extends BaseResourceCreateStep {
   public CreateSentinelAlertRulesStep(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator,
+      ResourceNameProvider resourceNameProvider,
       AlertRulesHelper alertRuleAdapter,
       LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration) {
-    super(armManagers, parametersResolver, resourceNameGenerator);
+    super(armManagers, parametersResolver, resourceNameProvider);
     this.alertRulesHelper = alertRuleAdapter;
     this.landingZoneProtectedDataConfiguration = landingZoneProtectedDataConfiguration;
   }
@@ -136,5 +138,10 @@ public class CreateSentinelAlertRulesStep extends BaseResourceCreateStep {
             .withTriggerThreshold(0);
     alertRulesHelper.createAlertRule(
         fileAccessAttemptsRule, "UnauthorizedFileAccessAttempts", mrgName, workspaceName);
+  }
+
+  @Override
+  public List<ResourceNameRequirements> getResourceNameRequirements() {
+    return List.of();
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelRunPlaybookAutomationRule.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelRunPlaybookAutomationRule.java
@@ -2,9 +2,10 @@ package bio.terra.landingzone.stairway.flight.create.resource.step;
 
 import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfiguration;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
+import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.landingzone.stairway.flight.exception.MissingRequiredFieldsException;
 import bio.terra.stairway.FlightContext;
 import com.azure.resourcemanager.securityinsights.models.AutomationRuleRunPlaybookAction;
@@ -27,9 +28,9 @@ public class CreateSentinelRunPlaybookAutomationRule extends BaseResourceCreateS
   public CreateSentinelRunPlaybookAutomationRule(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator,
+      ResourceNameProvider resourceNameProvider,
       LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration) {
-    super(armManagers, parametersResolver, resourceNameGenerator);
+    super(armManagers, parametersResolver, resourceNameProvider);
     this.landingZoneProtectedDataConfiguration = landingZoneProtectedDataConfiguration;
   }
 
@@ -87,5 +88,10 @@ public class CreateSentinelRunPlaybookAutomationRule extends BaseResourceCreateS
   @Override
   protected Optional<String> getResourceId(FlightContext context) {
     return Optional.empty();
+  }
+
+  @Override
+  public List<ResourceNameRequirements> getResourceNameRequirements() {
+    return List.of();
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelStep.java
@@ -1,11 +1,13 @@
 package bio.terra.landingzone.stairway.flight.create.resource.step;
 
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
+import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.landingzone.stairway.flight.exception.MissingRequiredFieldsException;
 import bio.terra.stairway.FlightContext;
+import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,8 +20,8 @@ public class CreateSentinelStep extends BaseResourceCreateStep {
   public CreateSentinelStep(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator) {
-    super(armManagers, parametersResolver, resourceNameGenerator);
+      ResourceNameProvider resourceNameProvider) {
+    super(armManagers, parametersResolver, resourceNameProvider);
   }
 
   @Override
@@ -69,5 +71,11 @@ public class CreateSentinelStep extends BaseResourceCreateStep {
   @Override
   protected Optional<String> getResourceId(FlightContext context) {
     return Optional.ofNullable(context.getWorkingMap().get(SENTINEL_ID, String.class));
+  }
+
+  @Override
+  public List<ResourceNameRequirements> getResourceNameRequirements() {
+    // we don't generate name for sentinel. Azure accepts only 'default' as a name
+    return List.of();
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAccountCorsRules.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAccountCorsRules.java
@@ -1,11 +1,12 @@
 package bio.terra.landingzone.stairway.flight.create.resource.step;
 
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
 import bio.terra.landingzone.library.landingzones.definition.factories.parameters.ParametersExtractor;
 import bio.terra.landingzone.library.landingzones.definition.factories.parameters.StorageAccountBlobCorsParametersNames;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
+import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.stairway.FlightContext;
 import com.azure.resourcemanager.storage.models.CorsRule;
 import com.azure.resourcemanager.storage.models.CorsRuleAllowedMethodsItem;
@@ -22,8 +23,8 @@ public class CreateStorageAccountCorsRules extends BaseResourceCreateStep {
   public CreateStorageAccountCorsRules(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator) {
-    super(armManagers, parametersResolver, resourceNameGenerator);
+      ResourceNameProvider resourceNameProvider) {
+    super(armManagers, parametersResolver, resourceNameProvider);
   }
 
   @Override
@@ -57,6 +58,11 @@ public class CreateStorageAccountCorsRules extends BaseResourceCreateStep {
   @Override
   protected Optional<String> getResourceId(FlightContext context) {
     return Optional.empty();
+  }
+
+  @Override
+  public List<ResourceNameRequirements> getResourceNameRequirements() {
+    return List.of();
   }
 
   /**

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAccountStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAccountStep.java
@@ -8,9 +8,12 @@ import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
 import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
+import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.stairway.FlightContext;
 import com.azure.resourcemanager.storage.models.SkuName;
 import com.azure.resourcemanager.storage.models.StorageAccountSkuType;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -25,8 +28,8 @@ public class CreateStorageAccountStep extends BaseResourceCreateStep {
   public CreateStorageAccountStep(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator) {
-    super(armManagers, parametersResolver, resourceNameGenerator);
+      ResourceNameProvider resourceNameProvider) {
+    super(armManagers, parametersResolver, resourceNameProvider);
   }
 
   @Override
@@ -34,8 +37,7 @@ public class CreateStorageAccountStep extends BaseResourceCreateStep {
     var landingZoneId =
         getParameterOrThrow(
             context.getInputParameters(), LandingZoneFlightMapKeys.LANDING_ZONE_ID, UUID.class);
-    String storageAccountName =
-        resourceNameGenerator.nextName(ResourceNameGenerator.MAX_STORAGE_ACCOUNT_NAME_LENGTH);
+    String storageAccountName = resourceNameProvider.getName(getResourceType());
     var storage =
         armManagers
             .azureResourceManager()
@@ -87,5 +89,12 @@ public class CreateStorageAccountStep extends BaseResourceCreateStep {
   @Override
   protected Optional<String> getResourceId(FlightContext context) {
     return Optional.ofNullable(context.getWorkingMap().get(STORAGE_ACCOUNT_ID, String.class));
+  }
+
+  @Override
+  public List<ResourceNameRequirements> getResourceNameRequirements() {
+    return List.of(
+        new ResourceNameRequirements(
+            getResourceType(), ResourceNameGenerator.MAX_STORAGE_ACCOUNT_NAME_LENGTH));
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAuditLogSettingsStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAuditLogSettingsStep.java
@@ -3,7 +3,10 @@ package bio.terra.landingzone.stairway.flight.create.resource.step;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
+import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.stairway.FlightContext;
+import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,8 +18,8 @@ public class CreateStorageAuditLogSettingsStep extends BaseResourceCreateStep {
   public CreateStorageAuditLogSettingsStep(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator) {
-    super(armManagers, parametersResolver, resourceNameGenerator);
+      ResourceNameProvider resourceNameProvider) {
+    super(armManagers, parametersResolver, resourceNameProvider);
   }
 
   @Override
@@ -30,8 +33,7 @@ public class CreateStorageAuditLogSettingsStep extends BaseResourceCreateStep {
             CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_WORKSPACE_ID,
             String.class);
 
-    var storageAuditLogSettingsName =
-        resourceNameGenerator.nextName(ResourceNameGenerator.MAX_DIAGNOSTIC_SETTING_NAME_LENGTH);
+    var storageAuditLogSettingsName = resourceNameProvider.getName(getResourceType());
 
     var storageAuditLogSettings =
         armManagers
@@ -61,5 +63,12 @@ public class CreateStorageAuditLogSettingsStep extends BaseResourceCreateStep {
   @Override
   protected Optional<String> getResourceId(FlightContext context) {
     return Optional.empty();
+  }
+
+  @Override
+  public List<ResourceNameRequirements> getResourceNameRequirements() {
+    return List.of(
+        new ResourceNameRequirements(
+            getResourceType(), ResourceNameGenerator.MAX_DIAGNOSTIC_SETTING_NAME_LENGTH));
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateVirtualNetworkLinkStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateVirtualNetworkLinkStep.java
@@ -1,16 +1,17 @@
 package bio.terra.landingzone.stairway.flight.create.resource.step;
 
-import static bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator.MAX_PRIVATE_VNET_LINK_NAME_LENGTH;
-
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
 import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
+import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.stairway.FlightContext;
 import com.azure.core.management.SubResource;
 import com.azure.resourcemanager.privatedns.fluent.models.VirtualNetworkLinkInner;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -25,8 +26,8 @@ public class CreateVirtualNetworkLinkStep extends BaseResourceCreateStep {
   public CreateVirtualNetworkLinkStep(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator) {
-    super(armManagers, parametersResolver, resourceNameGenerator);
+      ResourceNameProvider resourceNameProvider) {
+    super(armManagers, parametersResolver, resourceNameProvider);
   }
 
   @Override
@@ -52,7 +53,7 @@ public class CreateVirtualNetworkLinkStep extends BaseResourceCreateStep {
             .createOrUpdate(
                 getMRGName(context),
                 dns.resourceName().orElseThrow(),
-                resourceNameGenerator.nextName(MAX_PRIVATE_VNET_LINK_NAME_LENGTH),
+                resourceNameProvider.getName(getResourceType()),
                 new VirtualNetworkLinkInner()
                     .withLocation("global")
                     .withTags(
@@ -98,11 +99,18 @@ public class CreateVirtualNetworkLinkStep extends BaseResourceCreateStep {
 
   @Override
   protected String getResourceType() {
-    return "PrivateDnsZone";
+    return "VirtualNetworkLink";
   }
 
   @Override
   protected Optional<String> getResourceId(FlightContext context) {
     return Optional.ofNullable(context.getWorkingMap().get(VNET_LINK_ID, String.class));
+  }
+
+  @Override
+  public List<ResourceNameRequirements> getResourceNameRequirements() {
+    return List.of(
+        new ResourceNameRequirements(
+            getResourceType(), ResourceNameGenerator.MAX_PRIVATE_VNET_LINK_NAME_LENGTH));
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateVnetStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateVnetStep.java
@@ -8,6 +8,8 @@ import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
 import bio.terra.landingzone.library.landingzones.deployment.SubnetResourcePurpose;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
+import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.stairway.FlightContext;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.network.models.Delegation;
@@ -29,13 +31,13 @@ public class CreateVnetStep extends BaseResourceCreateStep {
   public CreateVnetStep(
       ArmManagers armManagers,
       ParametersResolver parametersResolver,
-      ResourceNameGenerator resourceNameGenerator) {
-    super(armManagers, parametersResolver, resourceNameGenerator);
+      ResourceNameProvider resourceNameProvider) {
+    super(armManagers, parametersResolver, resourceNameProvider);
   }
 
   @Override
   public void createResource(FlightContext context, ArmManagers armManagers) {
-    String vNetName = resourceNameGenerator.nextName(ResourceNameGenerator.MAX_VNET_NAME_LENGTH);
+    String vNetName = resourceNameProvider.getName(getResourceType());
     Network vNet = createVnetAndSubnets(context, armManagers, vNetName);
 
     setupPostgresSubnet(context, armManagers, vNet);
@@ -156,5 +158,12 @@ public class CreateVnetStep extends BaseResourceCreateStep {
   @Override
   protected Optional<String> getResourceId(FlightContext context) {
     return Optional.ofNullable(context.getWorkingMap().get(VNET_ID, String.class));
+  }
+
+  @Override
+  public List<ResourceNameRequirements> getResourceNameRequirements() {
+    return List.of(
+        new ResourceNameRequirements(
+            getResourceType(), ResourceNameGenerator.MAX_VNET_NAME_LENGTH));
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/exception/ResourceNameGenerationException.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/exception/ResourceNameGenerationException.java
@@ -1,0 +1,7 @@
+package bio.terra.landingzone.stairway.flight.exception;
+
+public class ResourceNameGenerationException extends RuntimeException {
+  public ResourceNameGenerationException(String message) {
+    super(message);
+  }
+}

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/ResourceNameProviderTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/ResourceNameProviderTest.java
@@ -88,7 +88,7 @@ class ResourceNameProviderTest {
 
       @Override
       protected String getResourceType() {
-        return resourceNameRequirements.resource();
+        return resourceNameRequirements.resourceType();
       }
 
       @Override

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/ResourceNameProviderTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/ResourceNameProviderTest.java
@@ -1,0 +1,100 @@
+package bio.terra.landingzone.stairway.flight;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
+import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
+import bio.terra.landingzone.stairway.flight.create.resource.step.BaseResourceCreateStep;
+import bio.terra.landingzone.stairway.flight.exception.ResourceNameGenerationException;
+import bio.terra.stairway.FlightContext;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+class ResourceNameProviderTest {
+  private final UUID LANDING_ZONE_ID = UUID.randomUUID();
+  private ResourceNameProvider resourceNameProvider;
+
+  @BeforeEach
+  void setup() {
+    resourceNameProvider = new ResourceNameProvider(LANDING_ZONE_ID);
+  }
+
+  @Test
+  void testGetNameSuccess() {
+    int resourceNameMaxLength = 26;
+    String resourceType = "SOME_RESOURCE";
+
+    createDummyStep(
+        resourceNameProvider, new ResourceNameRequirements(resourceType, resourceNameMaxLength));
+
+    var name = resourceNameProvider.getName(resourceType);
+
+    assertNotNull(name);
+    assertThat(name.length(), equalTo(resourceNameMaxLength));
+  }
+
+  @Test
+  void testStepIsNotRegisteredThrowsException() {
+    assertThrows(
+        ResourceNameGenerationException.class,
+        () -> resourceNameProvider.getName("NOT_REGISTERED_RESOURCE"));
+  }
+
+  @Test
+  void testStepWithSameResourceAlreadyRegisteredThrowsException() {
+    int resourceNameMaxLength = 26;
+    // step is registered for name generation during construction
+    createDummyStep(
+        resourceNameProvider, new ResourceNameRequirements("SOME_RESOURCE", resourceNameMaxLength));
+
+    assertThrows(
+        ResourceNameGenerationException.class,
+        () ->
+            createDummyStep(
+                resourceNameProvider,
+                new ResourceNameRequirements("SOME_RESOURCE", resourceNameMaxLength)));
+  }
+
+  private static BaseResourceCreateStep createDummyStep(
+      ResourceNameProvider resourceNameProvider,
+      ResourceNameRequirements resourceNameRequirements) {
+    return new BaseResourceCreateStep(
+        mock(ArmManagers.class), mock(ParametersResolver.class), resourceNameProvider) {
+      @Override
+      public List<ResourceNameRequirements> getResourceNameRequirements() {
+        return List.of(
+            new ResourceNameRequirements(
+                getResourceType(), resourceNameRequirements.maxNameLength()));
+      }
+
+      @Override
+      protected void createResource(FlightContext context, ArmManagers armManagers) {
+        // we don't need implementation here
+      }
+
+      @Override
+      protected void deleteResource(String resourceId) {
+        // we don't need implementation here
+      }
+
+      @Override
+      protected String getResourceType() {
+        return resourceNameRequirements.resource();
+      }
+
+      @Override
+      protected Optional<String> getResourceId(FlightContext context) {
+        return Optional.empty();
+      }
+    };
+  }
+}

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/BaseStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/BaseStepTest.java
@@ -7,13 +7,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
 import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
 import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
 import bio.terra.landingzone.stairway.flight.FlightTestUtils;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
 import bio.terra.profile.model.ProfileModel;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
@@ -35,7 +35,7 @@ class BaseStepTest {
   @Mock protected ArmManagers mockArmManagers;
   @Mock protected AzureResourceManager mockAzureResourceManager;
   @Mock protected ParametersResolver mockParametersResolver;
-  @Mock protected ResourceNameGenerator mockResourceNameGenerator;
+  @Mock protected ResourceNameProvider mockResourceNameProvider;
   @Mock protected FlightContext mockFlightContext;
 
   @Captor protected ArgumentCaptor<Map<String, String>> tagsCaptor;

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/ConnectLongTermLogStorageStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/ConnectLongTermLogStorageStepTest.java
@@ -3,7 +3,6 @@ package bio.terra.landingzone.stairway.flight.create.resource.step;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -47,7 +46,7 @@ class ConnectLongTermLogStorageStepTest extends BaseStepTest {
             CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_RESOURCE_KEY,
             buildLandingZoneResource()));
     var mockDataExport = mock(DataExport.class);
-    when(mockResourceNameGenerator.nextName(anyInt())).thenReturn("fake");
+    when(mockResourceNameProvider.getName(anyString())).thenReturn("fake");
     when(mockStorageHelper.createLogAnalyticsDataExport(
             anyString(), anyString(), anyString(), anyList(), anyString()))
         .thenReturn(mockDataExport);
@@ -55,7 +54,7 @@ class ConnectLongTermLogStorageStepTest extends BaseStepTest {
         new ConnectLongTermLogStorageStep(
             mockArmManagers,
             mockParametersResolver,
-            mockResourceNameGenerator,
+            mockResourceNameProvider,
             mockStorageHelper,
             List.of("FakeTableName"),
             Map.of(matchingRegionName, "exampleaccount"));
@@ -84,7 +83,7 @@ class ConnectLongTermLogStorageStepTest extends BaseStepTest {
         new ConnectLongTermLogStorageStep(
             mockArmManagers,
             mockParametersResolver,
-            mockResourceNameGenerator,
+            mockResourceNameProvider,
             mockStorageHelper,
             List.of("FakeTableName"),
             Map.of("westus", "exampleaccount"));
@@ -98,7 +97,7 @@ class ConnectLongTermLogStorageStepTest extends BaseStepTest {
         new ConnectLongTermLogStorageStep(
             mockArmManagers,
             mockParametersResolver,
-            mockResourceNameGenerator,
+            mockResourceNameProvider,
             mockStorageHelper,
             List.of("FakeTableName"),
             Map.of());

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksLogSettingsStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksLogSettingsStepTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfiguration;
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
 import bio.terra.landingzone.stairway.flight.FlightTestUtils;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
@@ -68,7 +67,7 @@ public class CreateAksLogSettingsStepTest extends BaseStepTest {
         new CreateAksLogSettingsStep(
             mockArmManagers,
             mockParametersResolver,
-            mockResourceNameGenerator,
+            mockResourceNameProvider,
             mockLandingZoneProtectedDataConfiguration);
   }
 
@@ -79,8 +78,7 @@ public class CreateAksLogSettingsStepTest extends BaseStepTest {
     final Map<String, String> storageAccountIds = Map.of("eastus", "ltsAccountEastUs");
 
     TargetManagedResourceGroup mrg = ResourceStepFixture.createDefaultMrg();
-    when(mockResourceNameGenerator.nextName(
-            ResourceNameGenerator.MAX_DIAGNOSTIC_SETTING_NAME_LENGTH))
+    when(mockResourceNameProvider.getName(createAksLogSettingsStep.getResourceType()))
         .thenReturn(aksDiagnosticSettingName);
     when(mockLandingZoneProtectedDataConfiguration.getLongTermStorageAccountIds())
         .thenReturn(storageAccountIds);

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAppInsightsStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAppInsightsStepTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
 import bio.terra.landingzone.stairway.flight.FlightTestUtils;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
@@ -74,7 +73,7 @@ class CreateAppInsightsStepTest extends BaseStepTest {
   void setup() {
     createAppInsightsStep =
         new CreateAppInsightsStep(
-            mockArmManagers, mockParametersResolver, mockResourceNameGenerator);
+            mockArmManagers, mockParametersResolver, mockResourceNameProvider);
   }
 
   @Test
@@ -82,8 +81,7 @@ class CreateAppInsightsStepTest extends BaseStepTest {
     final String logAnalyticsWorkspaceId = "logAnalyticsWorkspaceId";
     final String appInsightName = "appInsightName";
 
-    when(mockResourceNameGenerator.nextName(
-            ResourceNameGenerator.MAX_APP_INSIGHTS_COMPONENT_NAME_LENGTH))
+    when(mockResourceNameProvider.getName(createAppInsightsStep.getResourceType()))
         .thenReturn(appInsightName);
 
     TargetManagedResourceGroup mrg = ResourceStepFixture.createDefaultMrg();

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateBatchAccountStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateBatchAccountStepTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
 import bio.terra.landingzone.stairway.flight.FlightTestUtils;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
@@ -61,13 +60,13 @@ class CreateBatchAccountStepTest extends BaseStepTest {
   void setup() {
     createBatchAccountStep =
         new CreateBatchAccountStep(
-            mockArmManagers, mockParametersResolver, mockResourceNameGenerator);
+            mockArmManagers, mockParametersResolver, mockResourceNameProvider);
   }
 
   @Test
   void doStepSuccess() throws InterruptedException {
     TargetManagedResourceGroup mrg = ResourceStepFixture.createDefaultMrg();
-    when(mockResourceNameGenerator.nextName(ResourceNameGenerator.MAX_BATCH_ACCOUNT_NAME_LENGTH))
+    when(mockResourceNameProvider.getName(createBatchAccountStep.getResourceType()))
         .thenReturn(BATCH_ACCOUNT_NAME);
 
     setupFlightContext(

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateBatchLogSettingsStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateBatchLogSettingsStepTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
 import bio.terra.landingzone.stairway.flight.FlightTestUtils;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
@@ -61,7 +60,7 @@ class CreateBatchLogSettingsStepTest extends BaseStepTest {
   void setup() {
     createBatchLogSettingsStep =
         new CreateBatchLogSettingsStep(
-            mockArmManagers, mockParametersResolver, mockResourceNameGenerator);
+            mockArmManagers, mockParametersResolver, mockResourceNameProvider);
   }
 
   @Test
@@ -70,8 +69,7 @@ class CreateBatchLogSettingsStepTest extends BaseStepTest {
     final String batchAccountId = "batchAccountId";
     final String batchLogSettingName = "batchLogSettingName";
 
-    when(mockResourceNameGenerator.nextName(
-            ResourceNameGenerator.MAX_DIAGNOSTIC_SETTING_NAME_LENGTH))
+    when(mockResourceNameProvider.getName(createBatchLogSettingsStep.getResourceType()))
         .thenReturn(batchLogSettingName);
 
     TargetManagedResourceGroup mrg = ResourceStepFixture.createDefaultMrg();

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateLandingZoneIdentityStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateLandingZoneIdentityStepTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
 import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
 import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
@@ -44,15 +43,14 @@ public class CreateLandingZoneIdentityStepTest extends BaseStepTest {
   void setup() {
     testStep =
         new CreateLandingZoneIdentityStep(
-            mockArmManagers, mockParametersResolver, mockResourceNameGenerator);
+            mockArmManagers, mockParametersResolver, mockResourceNameProvider);
   }
 
   @Test
   void doStepSuccess() throws InterruptedException {
     final String uamiName = "uami-name";
 
-    when(mockResourceNameGenerator.nextName(ResourceNameGenerator.UAMI_NAME_LENGTH))
-        .thenReturn(uamiName);
+    when(mockResourceNameProvider.getName(testStep.getResourceType())).thenReturn(uamiName);
 
     TargetManagedResourceGroup mrg = ResourceStepFixture.createDefaultMrg();
     setupFlightContext(

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateLogAnalyticsDataCollectionRulesStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateLogAnalyticsDataCollectionRulesStepTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
 import bio.terra.landingzone.stairway.flight.FlightTestUtils;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
@@ -71,7 +70,7 @@ class CreateLogAnalyticsDataCollectionRulesStepTest extends BaseStepTest {
   void setup() {
     createLogAnalyticsDataCollectionRulesStep =
         new CreateLogAnalyticsDataCollectionRulesStep(
-            mockArmManagers, mockParametersResolver, mockResourceNameGenerator);
+            mockArmManagers, mockParametersResolver, mockResourceNameProvider);
   }
 
   @Test
@@ -79,8 +78,8 @@ class CreateLogAnalyticsDataCollectionRulesStepTest extends BaseStepTest {
     final String logAnalyticsWorkspaceId = "logAnalyticsWorkspaceId";
     final String dataCollectionRuleName = "storageAuditLogSettingsName";
 
-    when(mockResourceNameGenerator.nextName(
-            ResourceNameGenerator.MAX_DATA_COLLECTION_RULE_NAME_LENGTH))
+    when(mockResourceNameProvider.getName(
+            createLogAnalyticsDataCollectionRulesStep.getResourceType()))
         .thenReturn(dataCollectionRuleName);
 
     TargetManagedResourceGroup mrg = ResourceStepFixture.createDefaultMrg();

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateLogAnalyticsWorkspaceStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateLogAnalyticsWorkspaceStepTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.CromwellBaseResourcesFactory;
 import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
 import bio.terra.landingzone.stairway.flight.FlightTestUtils;
@@ -68,7 +67,7 @@ class CreateLogAnalyticsWorkspaceStepTest extends BaseStepTest {
   void setup() {
     createLogAnalyticsWorkspaceStep =
         new CreateLogAnalyticsWorkspaceStep(
-            mockArmManagers, mockParametersResolver, mockResourceNameGenerator);
+            mockArmManagers, mockParametersResolver, mockResourceNameProvider);
   }
 
   @Test
@@ -76,8 +75,7 @@ class CreateLogAnalyticsWorkspaceStepTest extends BaseStepTest {
     final String logAnalyticsWorkspaceName = "logAnalyticsWorkspaceName";
     final int retentionInDays = 30;
 
-    when(mockResourceNameGenerator.nextName(
-            ResourceNameGenerator.MAX_LOG_ANALYTICS_WORKSPACE_NAME_LENGTH))
+    when(mockResourceNameProvider.getName(createLogAnalyticsWorkspaceStep.getResourceType()))
         .thenReturn(logAnalyticsWorkspaceName);
 
     TargetManagedResourceGroup mrg = ResourceStepFixture.createDefaultMrg();

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreatePostgresDNSStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreatePostgresDNSStepTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
 import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
 import bio.terra.landingzone.stairway.flight.FlightTestUtils;
@@ -44,15 +43,14 @@ public class CreatePostgresDNSStepTest extends BaseStepTest {
   void setup() {
     testStep =
         new CreatePostgresqlDNSStep(
-            mockArmManagers, mockParametersResolver, mockResourceNameGenerator);
+            mockArmManagers, mockParametersResolver, mockResourceNameProvider);
   }
 
   @Test
   void doStepSuccess() throws InterruptedException {
     final String resourceName = UUID.randomUUID().toString();
 
-    when(mockResourceNameGenerator.nextName(ResourceNameGenerator.MAX_PRIVATE_DNS_ZONE_NAME_LENGTH))
-        .thenReturn(resourceName);
+    when(mockResourceNameProvider.getName(testStep.getResourceType())).thenReturn(resourceName);
 
     TargetManagedResourceGroup mrg = ResourceStepFixture.createDefaultMrg();
     setupFlightContext(

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreatePostgresLogSettingsStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreatePostgresLogSettingsStepTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
 import bio.terra.landingzone.stairway.flight.FlightTestUtils;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
@@ -62,7 +61,7 @@ class CreatePostgresLogSettingsStepTest extends BaseStepTest {
   void setup() {
     createPostgresLogSettingsStep =
         new CreatePostgresLogSettingsStep(
-            mockArmManagers, mockParametersResolver, mockResourceNameGenerator);
+            mockArmManagers, mockParametersResolver, mockResourceNameProvider);
   }
 
   @Test
@@ -71,8 +70,7 @@ class CreatePostgresLogSettingsStepTest extends BaseStepTest {
     final String postgreSqlId = "postgreSqlId";
     final String postgresLogSettingsName = "postgresLogSettingsName";
 
-    when(mockResourceNameGenerator.nextName(
-            ResourceNameGenerator.MAX_DIAGNOSTIC_SETTING_NAME_LENGTH))
+    when(mockResourceNameProvider.getName(createPostgresLogSettingsStep.getResourceType()))
         .thenReturn(postgresLogSettingsName);
 
     TargetManagedResourceGroup mrg = ResourceStepFixture.createDefaultMrg();

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreatePostgresqlDbStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreatePostgresqlDbStepTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.CromwellBaseResourcesFactory;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
 import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
@@ -74,7 +73,7 @@ class CreatePostgresqlDbStepTest extends BaseStepTest {
   void setup() {
     createPostgresqlDbStep =
         new CreatePostgresqlDbStep(
-            mockArmManagers, mockParametersResolver, mockResourceNameGenerator);
+            mockArmManagers, mockParametersResolver, mockResourceNameProvider);
   }
 
   @Test
@@ -82,8 +81,7 @@ class CreatePostgresqlDbStepTest extends BaseStepTest {
     var postgresqlSku = "psqlSku";
 
     TargetManagedResourceGroup mrg = ResourceStepFixture.createDefaultMrg();
-    when(mockResourceNameGenerator.nextName(
-            ResourceNameGenerator.MAX_POSTGRESQL_SERVER_NAME_LENGTH))
+    when(mockResourceNameProvider.getName(createPostgresqlDbStep.getResourceType()))
         .thenReturn(POSTGRESQL_NAME);
 
     final String adminName = "adminName";

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateRelayNamespaceStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateRelayNamespaceStepTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
 import bio.terra.landingzone.stairway.flight.FlightTestUtils;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
@@ -62,13 +61,13 @@ class CreateRelayNamespaceStepTest extends BaseStepTest {
   void setup() {
     createRelayNamespaceStep =
         new CreateRelayNamespaceStep(
-            mockArmManagers, mockParametersResolver, mockResourceNameGenerator);
+            mockArmManagers, mockParametersResolver, mockResourceNameProvider);
   }
 
   @Test
   void doStepSuccess() throws InterruptedException {
     TargetManagedResourceGroup mrg = ResourceStepFixture.createDefaultMrg();
-    when(mockResourceNameGenerator.nextName(ResourceNameGenerator.MAX_RELAY_NS_NAME_LENGTH))
+    when(mockResourceNameProvider.getName(createRelayNamespaceStep.getResourceType()))
         .thenReturn(RELAY_NAMESPACE_NAME);
 
     setupFlightContext(

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelAlertRulesStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelAlertRulesStepTest.java
@@ -66,7 +66,7 @@ class CreateSentinelAlertRulesStepTest extends BaseStepTest {
         new CreateSentinelAlertRulesStep(
             mockArmManagers,
             mockParametersResolver,
-            mockResourceNameGenerator,
+            mockResourceNameProvider,
             mockAlertRuleAdapter,
             mockLandingZoneProtectedDataConfiguration);
 
@@ -102,7 +102,7 @@ class CreateSentinelAlertRulesStepTest extends BaseStepTest {
         new CreateSentinelAlertRulesStep(
             mockArmManagers,
             mockParametersResolver,
-            mockResourceNameGenerator,
+            mockResourceNameProvider,
             mockAlertRuleAdapter,
             mockLandingZoneProtectedDataConfiguration);
 

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelRunPlaybookAutomationRuleTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelRunPlaybookAutomationRuleTest.java
@@ -69,7 +69,7 @@ class CreateSentinelRunPlaybookAutomationRuleTest extends BaseStepTest {
         new CreateSentinelRunPlaybookAutomationRule(
             mockArmManagers,
             mockParametersResolver,
-            mockResourceNameGenerator,
+            mockResourceNameProvider,
             mockLandingZoneProtectedDataConfiguration);
   }
 

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateSentinelStepTest.java
@@ -48,7 +48,7 @@ class CreateSentinelStepTest extends BaseStepTest {
   @BeforeEach
   void setup() {
     createSentinelStep =
-        new CreateSentinelStep(mockArmManagers, mockParametersResolver, mockResourceNameGenerator);
+        new CreateSentinelStep(mockArmManagers, mockParametersResolver, mockResourceNameProvider);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAccountStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAccountStepTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.CromwellBaseResourcesFactory;
 import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
 import bio.terra.landingzone.stairway.flight.FlightTestUtils;
@@ -58,13 +57,13 @@ class CreateStorageAccountStepTest extends BaseStepTest {
   void setup() {
     createStorageAccountStep =
         new CreateStorageAccountStep(
-            mockArmManagers, mockParametersResolver, mockResourceNameGenerator);
+            mockArmManagers, mockParametersResolver, mockResourceNameProvider);
   }
 
   @Test
   void doStepSuccess() throws InterruptedException {
     TargetManagedResourceGroup mrg = ResourceStepFixture.createDefaultMrg();
-    when(mockResourceNameGenerator.nextName(ResourceNameGenerator.MAX_BATCH_ACCOUNT_NAME_LENGTH))
+    when(mockResourceNameProvider.getName(createStorageAccountStep.getResourceType()))
         .thenReturn(STORAGE_ACCOUNT_NAME);
     when(mockParametersResolver.getValue(
             CromwellBaseResourcesFactory.ParametersNames.STORAGE_ACCOUNT_SKU_TYPE.name()))

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAuditLogSettingsStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAuditLogSettingsStepTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
 import bio.terra.landingzone.stairway.flight.FlightTestUtils;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
@@ -61,7 +60,7 @@ class CreateStorageAuditLogSettingsStepTest extends BaseStepTest {
   void setup() {
     createStorageAuditLogSettingsStep =
         new CreateStorageAuditLogSettingsStep(
-            mockArmManagers, mockParametersResolver, mockResourceNameGenerator);
+            mockArmManagers, mockParametersResolver, mockResourceNameProvider);
   }
 
   @Test
@@ -70,8 +69,7 @@ class CreateStorageAuditLogSettingsStepTest extends BaseStepTest {
     final String storageAccountId = "storageAccountId";
     final String storageAuditLogSettingsName = "storageAuditLogSettingsName";
 
-    when(mockResourceNameGenerator.nextName(
-            ResourceNameGenerator.MAX_DIAGNOSTIC_SETTING_NAME_LENGTH))
+    when(mockResourceNameProvider.getName(createStorageAuditLogSettingsStep.getResourceType()))
         .thenReturn(storageAuditLogSettingsName);
 
     TargetManagedResourceGroup mrg = ResourceStepFixture.createDefaultMrg();

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateVirtualNetworkLinkStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateVirtualNetworkLinkStepTest.java
@@ -8,7 +8,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
 import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
@@ -52,7 +51,7 @@ public class CreateVirtualNetworkLinkStepTest extends BaseStepTest {
   void setup() {
     testStep =
         new CreateVirtualNetworkLinkStep(
-            mockArmManagers, mockParametersResolver, mockResourceNameGenerator);
+            mockArmManagers, mockParametersResolver, mockResourceNameProvider);
   }
 
   @Test
@@ -61,9 +60,7 @@ public class CreateVirtualNetworkLinkStepTest extends BaseStepTest {
     final String dnsZoneName = UUID.randomUUID().toString();
     final String vnetId = UUID.randomUUID().toString();
 
-    when(mockResourceNameGenerator.nextName(
-            ResourceNameGenerator.MAX_PRIVATE_VNET_LINK_NAME_LENGTH))
-        .thenReturn(resourceName);
+    when(mockResourceNameProvider.getName(testStep.getResourceType())).thenReturn(resourceName);
 
     TargetManagedResourceGroup mrg = ResourceStepFixture.createDefaultMrg();
     setupFlightContext(

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateVnetStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateVnetStepTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.CromwellBaseResourcesFactory;
 import bio.terra.landingzone.stairway.flight.FlightTestUtils;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
@@ -62,13 +61,12 @@ class CreateVnetStepTest extends BaseStepTest {
   @BeforeEach
   void setup() {
     createVnetStep =
-        new CreateVnetStep(mockArmManagers, mockParametersResolver, mockResourceNameGenerator);
+        new CreateVnetStep(mockArmManagers, mockParametersResolver, mockResourceNameProvider);
   }
 
   @Test
   void doStepSuccess() throws InterruptedException {
-    when(mockResourceNameGenerator.nextName(ResourceNameGenerator.MAX_VNET_NAME_LENGTH))
-        .thenReturn(VNET_NAME);
+    when(mockResourceNameProvider.getName(createVnetStep.getResourceType())).thenReturn(VNET_NAME);
 
     setupFlightContext(
         mockFlightContext,


### PR DESCRIPTION
This PR updates the process of resource name generation. Now we generate all required names upfront before LZ flight started.
Existing ResourceNameGenerator guarantees producing the same list of resource names for the same landing zone identifier. But it depends on internal sequence number which might generate different names for the same resource in case of server restart. For instance, in case server restarted in the middle of the flight where resource was already created but specific step isn't successfully completed yet, the ResourceNameGenerator would start name generation with a different internal sequence, producing different names.  As a result, we would have duplicate resources in LZ.

New ResourceNameProvider provides all steps (which are registered) upfront with a specific name based on requirements provided by a step itself. This new class is just a wrapper around existing ResourceNameGenerator. ResourceNameProvider still uses it internally to generate required names. This name provider was introduced to separate name generation from providing a name for a specific resource and also to simplify integration/refactoring. So, since we are generating names before flight it would produce the same sequence of names for a specific landing zone identifier. All steps which inherit BaseResourceCreateStep are registered by default for name generation.