### PR TITLE
WOR-991 Make LZ Storage Account Redundancy Configurable and set new default

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,12 +309,15 @@ The table below describes the current Landing Zone Definitions available in the 
             <strong>AKS_AUTOSCALING_ENABLED:</strong> Flag to enabled autoscaling for the AKS nodepool <br/>Default value: <i>false</i><br/><br/>
             <strong>AKS_AUTOSCALING_MIN:</strong> Minimum number of nodes in nodepool when autoscaling is enabled <br/>Default value: <i>1</i><br/><br/>
             <strong>AKS_AUTOSCALING_MAX:</strong> Maximum number of nodes in nodepool when autoscaling is enabled <br/>Default value: <i>3</i><br/><br/>
+            <strong>Azure storage account overview:</strong> <a href="https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview">documentation</a><br/><br/>
             <strong>Azure storage CORS configuration:</strong> <a href="https://learn.microsoft.com/en-us/rest/api/storageservices/cross-origin-resource-sharing--cors--support-for-the-azure-storage-services">documentation</a><br/><br/>
             <strong>STORAGE_ACCOUNT_BLOB_CORS_ALLOWED_ORIGINS:</strong> The origin domains that are permitted to make a request against the storage service via CORS <br/>Default value: <i>*</i><br/><br/>
             <strong>STORAGE_ACCOUNT_BLOB_CORS_ALLOWED_METHODS:</strong> The methods (HTTP request verbs) that the origin domain may use for a CORS request <br/>Default value: <i>GET,HEAD,OPTIONS,PUT,PATCH,POST,MERGE,DELETE</i><br/><br/>
             <strong>STORAGE_ACCOUNT_BLOB_CORS_ALLOWED_HEADERS:</strong> The request headers that the origin domain may specify on the CORS request <br/>Default value: <i>authorization,content-type,x-app-id,Referer,x-ms-blob-type,x-ms-copy-source,content-length</i><br/><br/>
             <strong>STORAGE_ACCOUNT_BLOB_CORS_EXPOSED_HEADERS:</strong> The response headers that may be sent in the response to the CORS request and exposed by the browser to the request issuer <br/>Default value: <i>Empty string</i><br/><br/>
             <strong>STORAGE_ACCOUNT_BLOB_CORS_MAX_AGE:</strong> The maximum amount time that a browser should cache the preflight OPTIONS request (in seconds) <br/>Default value: <i>0</i><br/><br/>
+            <strong>Azure storage SKU types:</strong> <a href="https://learn.microsoft.com/en-us/rest/api/storagerp/srp_sku_types">documentation</a><br/><br/>
+            <strong>STORAGE_ACCOUNT_SKU_TYPE:</strong> Type of storage account <br/>Default value: <i>Standard_LRS</i>; <br/>Accepted values: <i>Standard_LRS</i>, <i>Standard_GRS</i>, <i>Standard_RAGRS</i>, <i>Standard_ZRS</i>, <i>Premium_LRS;</i> Please see StorageAccountSkuType;<br/><br/>
         </td>
     </tr>
 <tr>

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactory.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactory.java
@@ -97,7 +97,8 @@ public class CromwellBaseResourcesFactory extends ArmClientsDefinitionFactory {
     AKS_MACHINE_TYPE,
     AKS_AUTOSCALING_ENABLED,
     AKS_AUTOSCALING_MIN,
-    AKS_AUTOSCALING_MAX
+    AKS_AUTOSCALING_MAX,
+    STORAGE_ACCOUNT_SKU_TYPE
   }
 
   CromwellBaseResourcesFactory() {}

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/validation/AksParametersValidator.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/validation/AksParametersValidator.java
@@ -6,8 +6,6 @@ import bio.terra.landingzone.library.landingzones.definition.factories.exception
 import java.util.Optional;
 
 public class AksParametersValidator implements InputParameterValidator {
-  static final String WRONG_PARAMETER_VALUE_MESSAGE = "Value of the '%s' parameter is not valid.";
-
   private final StringBuilder sbErrors = new StringBuilder();
 
   @Override
@@ -59,13 +57,5 @@ public class AksParametersValidator implements InputParameterValidator {
     }
 
     return Optional.empty();
-  }
-
-  private <E extends Enum<E>> String buildErrorMessage(E p, String details) {
-    return wrongParameterMessage(p) + details;
-  }
-
-  private <E extends Enum<E>> String wrongParameterMessage(E p) {
-    return String.format(WRONG_PARAMETER_VALUE_MESSAGE, p.name());
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/validation/BlobCorsParametersValidator.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/validation/BlobCorsParametersValidator.java
@@ -12,7 +12,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class BlobCorsParametersValidator implements InputParameterValidator {
-  static final String WRONG_PARAMETER_VALUE_MESSAGE = "Value of the '%s' parameter is not valid.";
   static final String HEADERS_INVALID_CHARACTERS = "[@(){}\\[\\]<>;:/\\\\]";
 
   private final Pattern headersInvalidCharactersPattern =
@@ -108,14 +107,6 @@ public class BlobCorsParametersValidator implements InputParameterValidator {
                   HEADERS_INVALID_CHARACTERS)));
     }
     return Optional.empty();
-  }
-
-  private String buildErrorMessage(StorageAccountBlobCorsParametersNames p, String details) {
-    return wrongParameterMessage(p) + details;
-  }
-
-  private String wrongParameterMessage(StorageAccountBlobCorsParametersNames p) {
-    return String.format(WRONG_PARAMETER_VALUE_MESSAGE, p.name());
   }
 
   private String getCsvListOfAllowedMethodValues() {

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/validation/InputParameterValidator.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/validation/InputParameterValidator.java
@@ -4,5 +4,15 @@ import bio.terra.landingzone.library.landingzones.definition.factories.Parameter
 import bio.terra.landingzone.library.landingzones.definition.factories.exception.InvalidInputParameterException;
 
 public interface InputParameterValidator {
+  String WRONG_PARAMETER_VALUE_MESSAGE = "Value of the '%s' parameter is not valid.";
+
   void validate(ParametersResolver parametersResolver) throws InvalidInputParameterException;
+
+  default <E extends Enum<E>> String buildErrorMessage(E p, String details) {
+    return wrongParameterMessage(p) + details;
+  }
+
+  default <E extends Enum<E>> String wrongParameterMessage(E p) {
+    return String.format(WRONG_PARAMETER_VALUE_MESSAGE, p.name());
+  }
 }

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/validation/InputParametersValidationFactory.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/validation/InputParametersValidationFactory.java
@@ -14,10 +14,16 @@ public class InputParametersValidationFactory {
   }
 
   private static List<InputParameterValidator> buildCromwellLandingZoneValidators() {
-    return List.of(new AksParametersValidator(), new BlobCorsParametersValidator());
+    return List.of(
+        new AksParametersValidator(),
+        new BlobCorsParametersValidator(),
+        new StorageAccountSkuTypeValidator());
   }
 
   private static List<InputParameterValidator> buildProtectedDataLandingZoneValidators() {
-    return List.of(new AksParametersValidator(), new BlobCorsParametersValidator());
+    return List.of(
+        new AksParametersValidator(),
+        new BlobCorsParametersValidator(),
+        new StorageAccountSkuTypeValidator());
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/validation/StorageAccountSkuTypeValidator.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/validation/StorageAccountSkuTypeValidator.java
@@ -1,0 +1,50 @@
+package bio.terra.landingzone.library.landingzones.definition.factories.validation;
+
+import bio.terra.landingzone.library.landingzones.definition.factories.CromwellBaseResourcesFactory;
+import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
+import bio.terra.landingzone.library.landingzones.definition.factories.exception.InvalidInputParameterException;
+import com.azure.resourcemanager.storage.models.SkuName;
+import java.util.Optional;
+import java.util.Set;
+
+public class StorageAccountSkuTypeValidator implements InputParameterValidator {
+  private final StringBuilder sbErrors = new StringBuilder();
+
+  @Override
+  public void validate(ParametersResolver parametersResolver)
+      throws InvalidInputParameterException {
+    Optional<String> storageAccountSkuValueValidationMessage =
+        validateStorageAccountSkuType(parametersResolver);
+    storageAccountSkuValueValidationMessage.ifPresent(s -> sbErrors.append(s).append(" "));
+
+    if (!sbErrors.isEmpty()) {
+      throw new InvalidInputParameterException(sbErrors.toString());
+    }
+  }
+
+  private Optional<String> validateStorageAccountSkuType(ParametersResolver parametersResolver) {
+    String value =
+        parametersResolver.getValue(
+            CromwellBaseResourcesFactory.ParametersNames.STORAGE_ACCOUNT_SKU_TYPE.name());
+
+    Set<String> acceptedValues = getAcceptedValues();
+    String errorMessage =
+        buildErrorMessage(
+            CromwellBaseResourcesFactory.ParametersNames.STORAGE_ACCOUNT_SKU_TYPE,
+            String.format(" Accepted values: [%s].", String.join(",", acceptedValues)));
+
+    return acceptedValues.contains(value) ? Optional.empty() : Optional.of(errorMessage);
+  }
+
+  private Set<String> getAcceptedValues() {
+    // possible values are based on StorageAccountSkuType which is build based on SkuName.
+    // since StorageAccountSkuType is a subset of SkuName returning here only those values which
+    // can be mapped to a certain value in StorageAccountSkuType
+    return Set.of(
+        SkuName.STANDARD_LRS.toString(),
+        SkuName.STANDARD_GRS.toString(),
+        SkuName.STANDARD_RAGRS.toString(),
+        SkuName.STANDARD_ZRS.toString(),
+        SkuName.PREMIUM_LRS.toString());
+  }
+}

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/LandingZoneDefaultParameters.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/LandingZoneDefaultParameters.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-// TODO: spread parameters among flight steps
 public class LandingZoneDefaultParameters {
   private LandingZoneDefaultParameters() {}
 

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/LandingZoneDefaultParameters.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/LandingZoneDefaultParameters.java
@@ -11,6 +11,7 @@ import bio.terra.landingzone.library.landingzones.definition.factories.parameter
 import com.azure.resourcemanager.containerservice.models.ContainerServiceVMSizeTypes;
 import com.azure.resourcemanager.postgresqlflexibleserver.models.ServerVersion;
 import com.azure.resourcemanager.postgresqlflexibleserver.models.SkuTier;
+import com.azure.resourcemanager.storage.models.StorageAccountSkuType;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -75,6 +76,9 @@ public class LandingZoneDefaultParameters {
     defaultValues.put(
         StorageAccountBlobCorsParametersNames.STORAGE_ACCOUNT_BLOB_CORS_MAX_AGE.name(),
         STORAGE_ACCOUNT_BLOB_CORS_MAX_AGE_DEFAULT);
+    defaultValues.put(
+        CromwellBaseResourcesFactory.ParametersNames.STORAGE_ACCOUNT_SKU_TYPE.name(),
+        StorageAccountSkuType.STANDARD_LRS.name().toString());
     return defaultValues;
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAccountStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAccountStep.java
@@ -2,12 +2,15 @@ package bio.terra.landingzone.stairway.flight.create.resource.step;
 
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
+import bio.terra.landingzone.library.landingzones.definition.factories.CromwellBaseResourcesFactory;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
 import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
 import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
 import bio.terra.stairway.FlightContext;
+import com.azure.resourcemanager.storage.models.SkuName;
+import com.azure.resourcemanager.storage.models.StorageAccountSkuType;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -40,6 +43,12 @@ public class CreateStorageAccountStep extends BaseResourceCreateStep {
             .define(storageAccountName)
             .withRegion(getMRGRegionName(context))
             .withExistingResourceGroup(getMRGName(context))
+            .withSku(
+                StorageAccountSkuType.fromSkuName(
+                    SkuName.fromString(
+                        parametersResolver.getValue(
+                            CromwellBaseResourcesFactory.ParametersNames.STORAGE_ACCOUNT_SKU_TYPE
+                                .name()))))
             .disableBlobPublicAccess()
             .withTags(
                 Map.of(

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/validation/StorageAccountSkuTypeValidatorTest.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/validation/StorageAccountSkuTypeValidatorTest.java
@@ -1,14 +1,71 @@
 package bio.terra.landingzone.library.landingzones.definition.factories.validation;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import bio.terra.landingzone.library.landingzones.definition.factories.CromwellBaseResourcesFactory;
+import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
+import bio.terra.landingzone.library.landingzones.definition.factories.exception.InvalidInputParameterException;
+import com.azure.resourcemanager.storage.models.StorageAccountSkuType;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 @Tag("unit")
 class StorageAccountSkuTypeValidatorTest {
   private StorageAccountSkuTypeValidator validator;
 
+  @Mock ParametersResolver mockParametersResolver;
+
   @BeforeEach
   void setup() {
     validator = new StorageAccountSkuTypeValidator();
+  }
+
+  @ParameterizedTest
+  @MethodSource("validStorageAccountSkyTypeProvider")
+  void testSuccessValidation(String storageAccountSkuType) {
+    when(mockParametersResolver.getValue(
+            CromwellBaseResourcesFactory.ParametersNames.STORAGE_ACCOUNT_SKU_TYPE.name()))
+        .thenReturn(storageAccountSkuType);
+    assertDoesNotThrow(
+        () -> validator.validate(mockParametersResolver), "Validation should be successful.");
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidStorageAccountSkyTypeProvider")
+  void testFailureValidation(String storageAccountSkuType) {
+    when(mockParametersResolver.getValue(
+            CromwellBaseResourcesFactory.ParametersNames.STORAGE_ACCOUNT_SKU_TYPE.name()))
+        .thenReturn(storageAccountSkuType);
+
+    assertThrows(
+        InvalidInputParameterException.class, () -> validator.validate(mockParametersResolver));
+  }
+
+  private static Stream<Arguments> validStorageAccountSkyTypeProvider() {
+    return Stream.of(
+        Arguments.of(StorageAccountSkuType.STANDARD_LRS.name().toString()),
+        Arguments.of(StorageAccountSkuType.STANDARD_GRS.name().toString()),
+        Arguments.of(StorageAccountSkuType.STANDARD_RAGRS.name().toString()),
+        Arguments.of(StorageAccountSkuType.STANDARD_ZRS.name().toString()),
+        Arguments.of(StorageAccountSkuType.PREMIUM_LRS.name().toString()));
+  }
+
+  private static Stream<Arguments> invalidStorageAccountSkyTypeProvider() {
+    return Stream.of(
+        Arguments.of("PREMIUM_ZRS"),
+        Arguments.of("STANDARD_GZRS"),
+        Arguments.of("STANDARD_RAGZRS"),
+        Arguments.of("notSupportedValue"),
+        Arguments.of("fakeValue"));
   }
 }

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/validation/StorageAccountSkuTypeValidatorTest.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/validation/StorageAccountSkuTypeValidatorTest.java
@@ -1,0 +1,14 @@
+package bio.terra.landingzone.library.landingzones.definition.factories.validation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+
+@Tag("unit")
+class StorageAccountSkuTypeValidatorTest {
+  private StorageAccountSkuTypeValidator validator;
+
+  @BeforeEach
+  void setup() {
+    validator = new StorageAccountSkuTypeValidator();
+  }
+}

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAccountStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAccountStepTest.java
@@ -25,13 +25,11 @@ import com.azure.resourcemanager.storage.models.StorageAccountSkuType;
 import com.azure.resourcemanager.storage.models.StorageAccounts;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -63,15 +61,14 @@ class CreateStorageAccountStepTest extends BaseStepTest {
             mockArmManagers, mockParametersResolver, mockResourceNameGenerator);
   }
 
-  @ParameterizedTest
-  @MethodSource("storageAccountTypeProvider")
-  void doStepSuccess(StorageAccountSkuType storageAccountSkuType) throws InterruptedException {
+  @Test
+  void doStepSuccess() throws InterruptedException {
     TargetManagedResourceGroup mrg = ResourceStepFixture.createDefaultMrg();
     when(mockResourceNameGenerator.nextName(ResourceNameGenerator.MAX_BATCH_ACCOUNT_NAME_LENGTH))
         .thenReturn(STORAGE_ACCOUNT_NAME);
     when(mockParametersResolver.getValue(
             CromwellBaseResourcesFactory.ParametersNames.STORAGE_ACCOUNT_SKU_TYPE.name()))
-        .thenReturn(storageAccountSkuType.name().toString());
+        .thenReturn(StorageAccountSkuType.STANDARD_LRS.name().toString());
     setupFlightContext(
         mockFlightContext,
         Map.of(
@@ -88,7 +85,7 @@ class CreateStorageAccountStepTest extends BaseStepTest {
     verifyBasicTags(storageAccountTagsCaptor.getValue(), LANDING_ZONE_ID);
     assertThat(
         storageAccountSkuTypeCaptor.getValue().name().toString(),
-        equalTo(storageAccountSkuType.name().toString()));
+        equalTo(StorageAccountSkuType.STANDARD_LRS.name().toString()));
     verify(mockStorageAccountDefinitionStagesWithCreate, times(1)).create();
     verifyNoMoreInteractions(mockStorageAccountDefinitionStagesWithCreate);
   }
@@ -150,14 +147,5 @@ class CreateStorageAccountStepTest extends BaseStepTest {
         .thenReturn(mockStorageAccountDefinitionStagesBlank);
     when(mockAzureResourceManager.storageAccounts()).thenReturn(mockStorageAccounts);
     when(mockArmManagers.azureResourceManager()).thenReturn(mockAzureResourceManager);
-  }
-
-  private static Stream<Arguments> storageAccountTypeProvider() {
-    return Stream.of(
-        Arguments.of(StorageAccountSkuType.STANDARD_LRS),
-        Arguments.of(StorageAccountSkuType.STANDARD_GRS),
-        Arguments.of(StorageAccountSkuType.STANDARD_RAGRS),
-        Arguments.of(StorageAccountSkuType.STANDARD_ZRS),
-        Arguments.of(StorageAccountSkuType.PREMIUM_LRS));
   }
 }

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAccountStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAccountStepTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
+import bio.terra.landingzone.library.landingzones.definition.factories.CromwellBaseResourcesFactory;
 import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
 import bio.terra.landingzone.stairway.flight.FlightTestUtils;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
@@ -20,6 +21,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import com.azure.resourcemanager.storage.models.StorageAccount;
+import com.azure.resourcemanager.storage.models.StorageAccountSkuType;
 import com.azure.resourcemanager.storage.models.StorageAccounts;
 import java.util.Map;
 import java.util.UUID;
@@ -48,6 +50,7 @@ class CreateStorageAccountStepTest extends BaseStepTest {
   @Mock StorageAccount mockStorageAccount;
 
   @Captor ArgumentCaptor<Map<String, String>> storageAccountTagsCaptor;
+  @Captor ArgumentCaptor<StorageAccountSkuType> storageAccountSkuTypeCaptor;
 
   private CreateStorageAccountStep createStorageAccountStep;
 
@@ -63,7 +66,9 @@ class CreateStorageAccountStepTest extends BaseStepTest {
     TargetManagedResourceGroup mrg = ResourceStepFixture.createDefaultMrg();
     when(mockResourceNameGenerator.nextName(ResourceNameGenerator.MAX_BATCH_ACCOUNT_NAME_LENGTH))
         .thenReturn(STORAGE_ACCOUNT_NAME);
-
+    when(mockParametersResolver.getValue(
+            CromwellBaseResourcesFactory.ParametersNames.STORAGE_ACCOUNT_SKU_TYPE.name()))
+        .thenReturn("STANDARD_LRS" /*SkuName.STANDARD_LRS.toString()*/);
     setupFlightContext(
         mockFlightContext,
         Map.of(
@@ -78,6 +83,9 @@ class CreateStorageAccountStepTest extends BaseStepTest {
 
     assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
     verifyBasicTags(storageAccountTagsCaptor.getValue(), LANDING_ZONE_ID);
+    assertThat(
+        storageAccountSkuTypeCaptor.getValue().name().toString(),
+        equalTo(StorageAccountSkuType.STANDARD_LRS.name().toString()));
     verify(mockStorageAccountDefinitionStagesWithCreate, times(1)).create();
     verifyNoMoreInteractions(mockStorageAccountDefinitionStagesWithCreate);
   }
@@ -127,6 +135,9 @@ class CreateStorageAccountStepTest extends BaseStepTest {
     when(mockStorageAccountDefinitionStagesWithCreate.withTags(storageAccountTagsCaptor.capture()))
         .thenReturn(mockStorageAccountDefinitionStagesWithCreate);
     when(mockStorageAccountDefinitionStagesWithCreate.disableBlobPublicAccess())
+        .thenReturn(mockStorageAccountDefinitionStagesWithCreate);
+    when(mockStorageAccountDefinitionStagesWithCreate.withSku(
+            storageAccountSkuTypeCaptor.capture()))
         .thenReturn(mockStorageAccountDefinitionStagesWithCreate);
     when(mockStorageAccountDefinitionStagesWithGroup.withExistingResourceGroup(resourceGroupName))
         .thenReturn(mockStorageAccountDefinitionStagesWithCreate);


### PR DESCRIPTION
This PR Introduces new parameter for LZ creation:
-STORAGE_ACCOUNT_SKU_TYPE manages type of storage account. Default value is "Standard_LRS" (Standard Locally Redundant Storage).