### PR TITLE
[WOR-1057] Add test for storage account diagnostic settings

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -42,9 +42,9 @@ dependencies {
     // at commit time, azure-resourcemanager-monitor v2.20.0 is the latest but starting with v2.19.0
     // attributes of com.azure.resourcemanager.monitor.fluent.models.DataCollectionRuleResourceInner
     // are missing making creation of DataCollectionRules impossible via java client lib
-    implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-monitor', version: '2.27.0'
+    implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-monitor', version: '2.28.0'
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-applicationinsights', version: '1.0.0-beta.5'
-    implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager', version: '2.27.0'
+    implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager', version: '2.28.0'
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-securityinsights', version: '1.0.0-beta.4'
 
     implementation group: "io.kubernetes", name: "client-java", version: "18.0.0"

--- a/service/src/main/java/bio/terra/landingzone/service/landingzone/azure/model/LandingZoneDiagnosticSetting.java
+++ b/service/src/main/java/bio/terra/landingzone/service/landingzone/azure/model/LandingZoneDiagnosticSetting.java
@@ -1,0 +1,7 @@
+package bio.terra.landingzone.service.landingzone.azure.model;
+
+import com.azure.resourcemanager.monitor.models.LogSettings;
+import java.util.List;
+
+public record LandingZoneDiagnosticSetting(
+    String resourceId, String name, List<LogSettings> logs) {}

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/ProtectedDataStepsDefinitionProvider.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/ProtectedDataStepsDefinitionProvider.java
@@ -66,7 +66,7 @@ public class ProtectedDataStepsDefinitionProvider extends CromwellStepsDefinitio
                 resourceNameProvider,
                 new AlertRulesHelper(armManagers.securityInsightsManager()),
                 landingZoneProtectedDataConfiguration),
-            RetryRules.cloud()));
+            RetryRules.cloudLongRunning()));
     protectedDataSteps.add(
         Pair.of(
             new CreateAksLogSettingsStep(

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAuditLogSettingsStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateStorageAuditLogSettingsStep.java
@@ -3,6 +3,7 @@ package bio.terra.landingzone.stairway.flight.create.resource.step;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
+import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneDiagnosticSetting;
 import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
 import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.stairway.FlightContext;
@@ -14,6 +15,8 @@ import org.slf4j.LoggerFactory;
 public class CreateStorageAuditLogSettingsStep extends BaseResourceCreateStep {
   private static final Logger logger =
       LoggerFactory.getLogger(CreateStorageAuditLogSettingsStep.class);
+
+  public static final String STORAGE_AUDIT_LOG_SETTINGS_KEY = "STORAGE_AUDIT_LOG_SETTINGS";
 
   public CreateStorageAuditLogSettingsStep(
       ArmManagers armManagers,
@@ -46,6 +49,15 @@ public class CreateStorageAuditLogSettingsStep extends BaseResourceCreateStep {
             .withLog("StorageWrite", 0)
             .withLog("StorageDelete", 0)
             .create();
+
+    context
+        .getWorkingMap()
+        .put(
+            STORAGE_AUDIT_LOG_SETTINGS_KEY,
+            new LandingZoneDiagnosticSetting(
+                storageAuditLogSettings.resourceId(),
+                storageAuditLogSettingsName,
+                storageAuditLogSettings.logs()));
     logger.info(
         RESOURCE_CREATED, getResourceType(), storageAuditLogSettings.id(), getMRGName(context));
   }


### PR DESCRIPTION
## Why
The Azure sdk after 2.24 but before 2.28 broke creating diagnostic settings on storage accounts. This was particularly insidious because the SDK call would succeed, but no setting would be created in the MRG.

## This PR
* Pulls in a fixed version of the SDK
* Adds a test that reads back the diagnostic settings from the MRG and ensures the expected settings are present. 