### PR TITLE
[WOR-1114] Include alert rule description from template

### DIFF
--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/utils/AlertRulesHelper.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/utils/AlertRulesHelper.java
@@ -27,6 +27,7 @@ public class AlertRulesHelper {
 
     return new ScheduledAlertRule()
         .withQuery(scheduledtemplate.query())
+        .withDescription(scheduledtemplate.description())
         .withAlertRuleTemplateName(scheduledtemplate.name())
         .withDisplayName(scheduledtemplate.displayName())
         .withSuppressionEnabled(false)
@@ -56,6 +57,7 @@ public class AlertRulesHelper {
     var nrtTemplate = (NrtAlertRuleTemplate) template.innerModel();
     return new NrtAlertRule()
         .withQuery(nrtTemplate.query())
+        .withDescription(nrtTemplate.description())
         .withAlertRuleTemplateName(nrtTemplate.name())
         .withDisplayName(nrtTemplate.displayName())
         .withSuppressionEnabled(false)


### PR DESCRIPTION
Alert rule templates include a description, it should be included in the instantiated alert rule. 