### PR TITLE
WOR-1103 Emit usage data for azure resources

### DIFF
--- a/service/src/main/java/bio/terra/landingzone/common/utils/LandingZoneFlightBeanBag.java
+++ b/service/src/main/java/bio/terra/landingzone/common/utils/LandingZoneFlightBeanBag.java
@@ -2,6 +2,7 @@ package bio.terra.landingzone.common.utils;
 
 import bio.terra.landingzone.db.LandingZoneDao;
 import bio.terra.landingzone.library.LandingZoneManagerProvider;
+import bio.terra.landingzone.library.configuration.AzureCustomerUsageConfiguration;
 import bio.terra.landingzone.library.configuration.LandingZoneAzureConfiguration;
 import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfiguration;
 import bio.terra.landingzone.library.configuration.LandingZoneTestingConfiguration;
@@ -24,6 +25,7 @@ public class LandingZoneFlightBeanBag {
   private final LandingZoneBillingProfileManagerService bpmService;
   private final ObjectMapper objectMapper;
   private final LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration;
+  private final AzureCustomerUsageConfiguration azureCustomerUsageConfiguration;
 
   @Lazy
   @Autowired
@@ -36,6 +38,7 @@ public class LandingZoneFlightBeanBag {
       LandingZoneSamService samService,
       LandingZoneBillingProfileManagerService bpmService,
       LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration,
+      AzureCustomerUsageConfiguration azureCustomerUsageConfiguration,
       ObjectMapper objectMapper) {
     this.landingZoneService = landingZoneService;
     this.landingZoneDao = landingZoneDao;
@@ -45,6 +48,7 @@ public class LandingZoneFlightBeanBag {
     this.samService = samService;
     this.bpmService = bpmService;
     this.landingZoneProtectedDataConfiguration = landingZoneProtectedDataConfiguration;
+    this.azureCustomerUsageConfiguration = azureCustomerUsageConfiguration;
     this.objectMapper = objectMapper;
   }
 
@@ -86,5 +90,9 @@ public class LandingZoneFlightBeanBag {
 
   public LandingZoneProtectedDataConfiguration getLandingZoneProtectedDataConfiguration() {
     return landingZoneProtectedDataConfiguration;
+  }
+
+  public AzureCustomerUsageConfiguration getAzureCustomerUsageConfiguration() {
+    return azureCustomerUsageConfiguration;
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/library/LandingZoneManagerProvider.java
+++ b/service/src/main/java/bio/terra/landingzone/library/LandingZoneManagerProvider.java
@@ -1,5 +1,6 @@
 package bio.terra.landingzone.library;
 
+import bio.terra.landingzone.library.configuration.AzureCustomerUsageConfiguration;
 import bio.terra.landingzone.library.configuration.LandingZoneAzureConfiguration;
 import bio.terra.landingzone.library.landingzones.management.LandingZoneManager;
 import bio.terra.landingzone.model.LandingZoneTarget;
@@ -15,16 +16,23 @@ import org.springframework.stereotype.Component;
 @Component
 public class LandingZoneManagerProvider {
   private final LandingZoneAzureConfiguration azureConfiguration;
+  private AzureCustomerUsageConfiguration azureCustomerUsageConfiguration;
 
   @Autowired
-  public LandingZoneManagerProvider(LandingZoneAzureConfiguration azureConfiguration) {
+  public LandingZoneManagerProvider(
+      LandingZoneAzureConfiguration azureConfiguration,
+      AzureCustomerUsageConfiguration azureCustomerUsageConfiguration) {
     this.azureConfiguration = azureConfiguration;
+    this.azureCustomerUsageConfiguration = azureCustomerUsageConfiguration;
   }
 
   public LandingZoneManager createLandingZoneManager(LandingZoneTarget landingZoneTarget) {
     AzureProfile azureProfile = createAzureProfile(landingZoneTarget);
     return LandingZoneManager.createLandingZoneManager(
-        buildTokenCredential(), azureProfile, landingZoneTarget.azureResourceGroupId());
+        buildTokenCredential(),
+        azureProfile,
+        landingZoneTarget.azureResourceGroupId(),
+        azureCustomerUsageConfiguration.getUsageAttribute());
   }
 
   @NotNull

--- a/service/src/main/java/bio/terra/landingzone/library/configuration/AzureCustomerUsageConfiguration.java
+++ b/service/src/main/java/bio/terra/landingzone/library/configuration/AzureCustomerUsageConfiguration.java
@@ -1,0 +1,20 @@
+package bio.terra.landingzone.library.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties
+@ConfigurationProperties(prefix = "azure.customer")
+public class AzureCustomerUsageConfiguration {
+  private String usageAttribute;
+
+  public String getUsageAttribute() {
+    return usageAttribute;
+  }
+
+  public void setUsageAttribute(String usageAttribute) {
+    this.usageAttribute = usageAttribute;
+  }
+}

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/management/LandingZoneManager.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/management/LandingZoneManager.java
@@ -261,7 +261,7 @@ public class LandingZoneManager {
   }
 
   private static Optional<UserAgentPolicy> getUserAgentPolicy(String azureCustomerUsageAttribute) {
-    return azureCustomerUsageAttribute != null
+    return StringUtils.isNotEmpty(azureCustomerUsageAttribute)
         ? Optional.of(new UserAgentPolicy(azureCustomerUsageAttribute))
         : Optional.empty();
   }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlight.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlight.java
@@ -2,6 +2,7 @@ package bio.terra.landingzone.stairway.flight.create;
 
 import bio.terra.landingzone.common.utils.LandingZoneFlightBeanBag;
 import bio.terra.landingzone.common.utils.RetryRules;
+import bio.terra.landingzone.library.configuration.AzureCustomerUsageConfiguration;
 import bio.terra.landingzone.library.configuration.LandingZoneAzureConfiguration;
 import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfiguration;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
@@ -62,7 +63,11 @@ public class CreateLandingZoneResourcesFlight extends Flight {
     stepsDefinitionProvider =
         LandingZoneStepsDefinitionProviderFactory.create(
             StepsDefinitionFactoryType.fromString(landingZoneRequest.definition()));
-    armManagers = initializeArmManagers(inputParameters, flightBeanBag.getAzureConfiguration());
+    armManagers =
+        initializeArmManagers(
+            inputParameters,
+            flightBeanBag.getAzureConfiguration(),
+            flightBeanBag.getAzureCustomerUsageConfiguration());
     parametersResolver =
         new ParametersResolver(landingZoneRequest.parameters(), LandingZoneDefaultParameters.get());
 
@@ -83,7 +88,9 @@ public class CreateLandingZoneResourcesFlight extends Flight {
   }
 
   private ArmManagers initializeArmManagers(
-      FlightMap inputParameters, LandingZoneAzureConfiguration azureConfiguration) {
+      FlightMap inputParameters,
+      LandingZoneAzureConfiguration azureConfiguration,
+      AzureCustomerUsageConfiguration azureCustomerUsageConfiguration) {
     var billingProfile =
         inputParameters.get(LandingZoneFlightMapKeys.BILLING_PROFILE, ProfileModel.class);
     var landingZoneTarget = LandingZoneTarget.fromBillingProfile(billingProfile);
@@ -98,7 +105,8 @@ public class CreateLandingZoneResourcesFlight extends Flight {
             .clientSecret(azureConfiguration.getManagedAppClientSecret())
             .tenantId(azureConfiguration.getManagedAppTenantId())
             .build();
-    return LandingZoneManager.createArmManagers(tokenCredentials, azureProfile);
+    return LandingZoneManager.createArmManagers(
+        tokenCredentials, azureProfile, azureCustomerUsageConfiguration.getUsageAttribute());
   }
 
   private UUID getLandingZoneId(FlightMap inputParameters, LandingZoneRequest landingZoneRequest) {

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactoryTest.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactoryTest.java
@@ -35,7 +35,10 @@ class CromwellBaseResourcesFactoryTest extends LandingZoneTestFixture {
   void setUp() {
     landingZoneManager =
         LandingZoneManager.createLandingZoneManager(
-            tokenCredential, azureProfile, resourceGroup.name(), "" /*ignore this value in test*/);
+            tokenCredential,
+            azureProfile,
+            resourceGroup.name(),
+            null /*ignore this value in test*/);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactoryTest.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactoryTest.java
@@ -35,7 +35,7 @@ class CromwellBaseResourcesFactoryTest extends LandingZoneTestFixture {
   void setUp() {
     landingZoneManager =
         LandingZoneManager.createLandingZoneManager(
-            tokenCredential, azureProfile, resourceGroup.name());
+            tokenCredential, azureProfile, resourceGroup.name(), "" /*ignore this value in test*/);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/ManagedNetworkWithSharedResourcesFactoryTest.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/ManagedNetworkWithSharedResourcesFactoryTest.java
@@ -23,7 +23,7 @@ class ManagedNetworkWithSharedResourcesFactoryTest extends LandingZoneTestFixtur
   void setUp() {
     landingZoneManager =
         LandingZoneManager.createLandingZoneManager(
-            tokenCredential, azureProfile, resourceGroup.name());
+            tokenCredential, azureProfile, resourceGroup.name(), "" /*ignore this value in test*/);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/ManagedNetworkWithSharedResourcesFactoryTest.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/ManagedNetworkWithSharedResourcesFactoryTest.java
@@ -23,7 +23,10 @@ class ManagedNetworkWithSharedResourcesFactoryTest extends LandingZoneTestFixtur
   void setUp() {
     landingZoneManager =
         LandingZoneManager.createLandingZoneManager(
-            tokenCredential, azureProfile, resourceGroup.name(), "" /*ignore this value in test*/);
+            tokenCredential,
+            azureProfile,
+            resourceGroup.name(),
+            null /*ignore this value in test*/);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/management/LandingZoneManagerIntegrationTest.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/management/LandingZoneManagerIntegrationTest.java
@@ -52,7 +52,8 @@ class LandingZoneManagerIntegrationTest {
         LandingZoneManager.createLandingZoneManager(
             AzureIntegrationUtils.getAdminAzureCredentialsOrDie(),
             AzureIntegrationUtils.TERRA_DEV_AZURE_PROFILE,
-            resourceGroup.name());
+            resourceGroup.name(),
+            "" /*ignore this value in test*/);
   }
 
   @AfterEach

--- a/service/src/test/java/bio/terra/landingzone/library/landingzones/management/LandingZoneManagerIntegrationTest.java
+++ b/service/src/test/java/bio/terra/landingzone/library/landingzones/management/LandingZoneManagerIntegrationTest.java
@@ -53,7 +53,7 @@ class LandingZoneManagerIntegrationTest {
             AzureIntegrationUtils.getAdminAzureCredentialsOrDie(),
             AzureIntegrationUtils.TERRA_DEV_AZURE_PROFILE,
             resourceGroup.name(),
-            "" /*ignore this value in test*/);
+            null /*ignore this value in test*/);
   }
 
   @AfterEach

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
@@ -129,7 +129,10 @@ public class CreateLandingZoneResourcesFlightIntegrationTest extends BaseIntegra
             .id(UUID.randomUUID());
     landingZoneManager =
         LandingZoneManager.createLandingZoneManager(
-            tokenCredential, azureProfile, resourceGroup.name(), "" /*ignore this value in test*/);
+            tokenCredential,
+            azureProfile,
+            resourceGroup.name(),
+            null /*ignore this value in test*/);
   }
 
   @AfterEach

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
@@ -129,7 +129,7 @@ public class CreateLandingZoneResourcesFlightIntegrationTest extends BaseIntegra
             .id(UUID.randomUUID());
     landingZoneManager =
         LandingZoneManager.createLandingZoneManager(
-            tokenCredential, azureProfile, resourceGroup.name());
+            tokenCredential, azureProfile, resourceGroup.name(), "" /*ignore this value in test*/);
   }
 
   @AfterEach

--- a/service/src/test/resources/application-test.yml
+++ b/service/src/test/resources/application-test.yml
@@ -79,3 +79,8 @@ workspace:
     managedAppClientId: ${AZURE_PUBLISHER_CLIENT_ID}
     managedAppClientSecret: ${AZURE_PUBLISHER_CLIENT_SECRET}
     managedAppTenantId: ${AZURE_PUBLISHER_TENANT_ID}
+
+azure:
+  customer:
+    #track azure resource usage
+    usage-attribute: [REAL VALUE COMES FROM WSM]

--- a/testharness/src/main/resources/application.yml
+++ b/testharness/src/main/resources/application.yml
@@ -73,3 +73,8 @@ landingzone:
 terra.common:
   kubernetes:
     in-kubernetes: false
+
+azure:
+  customer:
+    #track azure resource usage
+    usage-attribute: [REAL VALUE COMES FROM WSM]

--- a/testharness/src/test/resources/application-test.yml
+++ b/testharness/src/test/resources/application-test.yml
@@ -31,3 +31,8 @@ landingzone:
 terra.common:
   kubernetes:
     in-kubernetes: false
+
+azure:
+  customer:
+    #track azure resource usage
+    usage-attribute: [REAL VALUE COMES FROM WSM]


### PR DESCRIPTION
Original POC - https://broadworkbench.atlassian.net/browse/WOR-829
Story - https://broadworkbench.atlassian.net/browse/WOR-1103
Azure documentation - https://learn.microsoft.com/en-us/partner-center/marketplace/azure-partner-customer-usage-attribution#use-resource-manager-apis

This change introduces new header attribute with specific value which will be injected into all Azure resource managers.