### PR TITLE
WOR-1146 Disable K8s cost optimization settings for monitoring

### DIFF
--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/CromwellStepsDefinitionProvider.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/CromwellStepsDefinitionProvider.java
@@ -5,7 +5,6 @@ import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfi
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
 import bio.terra.landingzone.library.landingzones.definition.factories.validation.InputParametersValidationFactory;
-import bio.terra.landingzone.stairway.flight.create.resource.step.CreateAksCostOptimizationDataCollectionRulesStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateAksStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateAppInsightsStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateBatchAccountStep;
@@ -100,10 +99,6 @@ public class CromwellStepsDefinitionProvider implements StepsDefinitionProvider 
             RetryRules.cloud()),
         Pair.of(
             new CreatePostgresLogSettingsStep(
-                armManagers, parametersResolver, resourceNameProvider),
-            RetryRules.cloud()),
-        Pair.of(
-            new CreateAksCostOptimizationDataCollectionRulesStep(
                 armManagers, parametersResolver, resourceNameProvider),
             RetryRules.cloud()),
         Pair.of(

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksCostOptimizationDataCollectionRulesStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksCostOptimizationDataCollectionRulesStep.java
@@ -45,6 +45,15 @@ import org.springframework.http.HttpStatus;
  * into current configuration since namespaceFilteringMode is set to Off. But can be added later by
  * adding 'namespaces' field into DataCollectionSettings.
  */
+
+/**
+ * **********************************!!! WARNING !!!**********************************
+ *
+ * <p>This step is currently excluded from LZ flight because it breaks K8s monitoring. The cost
+ * optimization settings required setting 'useAADAuth' parameter to true, but at the same time
+ * setting this value breaks K8s monitoring. This step is temporarily disabled until we find
+ * workaround or proper resolution.
+ */
 public class CreateAksCostOptimizationDataCollectionRulesStep extends BaseResourceCreateStep {
   public static final String AKS_COST_OPTIMIZATION_DATA_COLLECTION_RULE_ID =
       "AKS_COST_OPTIMIZATION_DATA_COLLECTION_RULE_ID";

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksCostOptimizationDataCollectionRulesStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksCostOptimizationDataCollectionRulesStep.java
@@ -50,7 +50,7 @@ import org.springframework.http.HttpStatus;
  * **********************************!!! WARNING !!!**********************************
  *
  * <p>This step is currently excluded from LZ flight because it breaks K8s monitoring. The cost
- * optimization settings required setting 'useAADAuth' parameter to true, but at the same time
+ * optimization settings requires following parameter 'useAADAuth' set to true, but at the same time
  * setting this value breaks K8s monitoring. This step is temporarily disabled until we find
  * workaround or proper resolution.
  */

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksStep.java
@@ -58,12 +58,7 @@ public class CreateAksStep extends BaseResourceCreateStep {
         "omsagent",
         new ManagedClusterAddonProfile()
             .withEnabled(true)
-            .withConfig(
-                Map.of(
-                    "logAnalyticsWorkspaceResourceID",
-                    logAnalyticsWorkspaceId,
-                    "useAADAuth",
-                    "true")));
+            .withConfig(Map.of("logAnalyticsWorkspaceResourceID", logAnalyticsWorkspaceId)));
 
     var aksName = resourceNameProvider.getName(getResourceType());
     var aksPartial =

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
@@ -162,7 +162,7 @@ public class CreateLandingZoneResourcesFlightIntegrationTest extends BaseIntegra
                   resources,
                   hasSize(
                       AggregateLandingZoneResourcesStep.deployedResourcesKeys.size()
-                          + 2 /*magic number which represents data collection rules which probably should not be tagged as shared resources*/));
+                          + 1 /*magic number which represents data collection rules which probably should not be tagged as shared resources*/));
             });
     var flightState = retrieveFlightState(jobId.toString());
     assertThat(flightState.getFlightStatus(), is(FlightStatus.SUCCESS));
@@ -171,7 +171,9 @@ public class CreateLandingZoneResourcesFlightIntegrationTest extends BaseIntegra
     // (these can silently fail to create, so we are making a explicit check here)
     assertDiagnosticSettings(
         CreateStorageAuditLogSettingsStep.STORAGE_AUDIT_LOG_SETTINGS_KEY, flightState);
-    assertAksCostOptimizedDataCollectionRule(flightState);
+    // disabling this validation because current data collection rule is currently disabled
+    // due to k8s monitoring issue. Jira - WOR-1147
+    // assertAksCostOptimizedDataCollectionRule(flightState);
 
     testCannotDeleteLandingZoneWithDependencies();
   }

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksStepTest.java
@@ -1,0 +1,227 @@
+package bio.terra.landingzone.stairway.flight.create.resource.step;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import bio.terra.landingzone.library.landingzones.definition.factories.CromwellBaseResourcesFactory;
+import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
+import bio.terra.landingzone.stairway.flight.FlightTestUtils;
+import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.exception.MissingRequiredFieldsException;
+import bio.terra.profile.model.ProfileModel;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepStatus;
+import com.azure.resourcemanager.containerservice.fluent.models.ManagedClusterInner;
+import com.azure.resourcemanager.containerservice.models.AgentPoolMode;
+import com.azure.resourcemanager.containerservice.models.ContainerServiceVMSizeTypes;
+import com.azure.resourcemanager.containerservice.models.KubernetesCluster;
+import com.azure.resourcemanager.containerservice.models.KubernetesClusterAgentPool;
+import com.azure.resourcemanager.containerservice.models.KubernetesClusters;
+import com.azure.resourcemanager.containerservice.models.ManagedClusterAddonProfile;
+import com.azure.resourcemanager.containerservice.models.ManagedClusterOidcIssuerProfile;
+import com.azure.resourcemanager.containerservice.models.ManagedClusterSecurityProfile;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("unit")
+class CreateAksStepTest extends BaseStepTest {
+  private static final String RESOURCE_ID = "aksId";
+
+  @Mock private KubernetesClusters mockKubernetesClusters;
+  @Mock private KubernetesCluster.DefinitionStages.Blank mockK8sDefinitionStageBlank;
+  @Mock private KubernetesCluster.DefinitionStages.WithGroup mockK8sDefinitionStageWithGroup;
+  @Mock private KubernetesCluster.DefinitionStages.WithVersion mockK8sDefinitionStageWithVersion;
+
+  @Mock
+  private KubernetesCluster.DefinitionStages.WithLinuxRootUsername
+      mockK8sDefinitionStageWithLinuxRootUsername;
+
+  @Mock private KubernetesCluster.DefinitionStages.WithCreate mockK8sDefinitionStageWithCreate;
+  @Mock private KubernetesClusterAgentPool.DefinitionStages.Blank mockK8sAPDefinitionStagesBlank;
+
+  @Mock
+  private KubernetesClusterAgentPool.DefinitionStages.WithAgentPoolVirtualMachineCount
+      mockK8sAPDefinitionStagesMachineCount;
+
+  @Mock
+  private KubernetesClusterAgentPool.DefinitionStages.WithAttach
+      mockK8sAPDefinitionStagesWithAttach;
+
+  @Mock private KubernetesCluster.Definition mockK8sDefinition;
+  @Mock private KubernetesCluster mockKubernetesCluster;
+
+  @Captor private ArgumentCaptor<Map<String, ManagedClusterAddonProfile>> addonProfileCaptor;
+  @Captor private ArgumentCaptor<Map<String, String>> tagsCaptor;
+
+  private CreateAksStep testStep;
+
+  @BeforeEach
+  void setup() {
+    testStep = new CreateAksStep(mockArmManagers, mockParametersResolver, mockResourceNameProvider);
+  }
+
+  @Test
+  void doStepSuccess() throws InterruptedException {
+    TargetManagedResourceGroup mrg = ResourceStepFixture.createDefaultMrg();
+    when(mockResourceNameProvider.getName(anyString())).thenReturn("aksName");
+    setupParameterResolver();
+    setupFlightContext(
+        mockFlightContext,
+        Map.of(
+            LandingZoneFlightMapKeys.BILLING_PROFILE,
+            new ProfileModel().id(UUID.randomUUID()),
+            LandingZoneFlightMapKeys.LANDING_ZONE_ID,
+            LANDING_ZONE_ID),
+        Map.of(
+            CreateVnetStep.VNET_ID,
+            "vNetId",
+            GetManagedResourceGroupInfo.TARGET_MRG_KEY,
+            mrg,
+            CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_WORKSPACE_ID,
+            "logAnalyticsWorkspaceId"));
+    setupArmManagersForDoStep();
+
+    var stepResult = testStep.doStep(mockFlightContext);
+
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(mockK8sDefinitionStageWithCreate, times(1)).create();
+    verifyNoMoreInteractions(mockK8sDefinitionStageWithCreate);
+    verifyBasicTags(tagsCaptor.getValue(), LANDING_ZONE_ID);
+    verifyAddonProfile(addonProfileCaptor.getValue());
+  }
+
+  @ParameterizedTest
+  @MethodSource("inputParameterProvider")
+  void doStepMissingInputParameterThrowsException(Map<String, Object> inputParameters) {
+    FlightMap flightMapInputParameters =
+        FlightTestUtils.prepareFlightInputParameters(inputParameters);
+    when(mockFlightContext.getInputParameters()).thenReturn(flightMapInputParameters);
+
+    assertThrows(MissingRequiredFieldsException.class, () -> testStep.doStep(mockFlightContext));
+  }
+
+  @ParameterizedTest
+  @MethodSource("workingParametersProvider")
+  void doStepMissingWorkingParameterThrowsException(Map<String, Object> workingParameters) {
+    FlightMap flightMapInputParameters =
+        FlightTestUtils.prepareFlightInputParameters(
+            Map.of(
+                LandingZoneFlightMapKeys.BILLING_PROFILE,
+                new ProfileModel().id(UUID.randomUUID()),
+                LandingZoneFlightMapKeys.LANDING_ZONE_ID,
+                LANDING_ZONE_ID));
+    FlightMap flightMapWorkingParameters =
+        FlightTestUtils.prepareFlightWorkingParameters(workingParameters);
+    when(mockFlightContext.getInputParameters()).thenReturn(flightMapInputParameters);
+    when(mockFlightContext.getWorkingMap()).thenReturn(flightMapWorkingParameters);
+
+    assertThrows(MissingRequiredFieldsException.class, () -> testStep.doStep(mockFlightContext));
+  }
+
+  // verify that we don't use useAADAuth. When this parameter exists it breaks K8s monitoring.
+  // At the same time cost optimization settings doesn't work properly without it
+  // WOR-1147 to find a workaround or fix and get this option back.
+  private void verifyAddonProfile(Map<String, ManagedClusterAddonProfile> addonProfile) {
+    ManagedClusterAddonProfile profile = addonProfile.get("omsagent");
+    assertNotNull(profile);
+    assertFalse(
+        profile.config().containsKey("useAADAuth"),
+        "'useAADAuth' breaks k8s monitoring and should not be used.");
+  }
+
+  private void setupParameterResolver() {
+    when(mockParametersResolver.getValue(
+            CromwellBaseResourcesFactory.ParametersNames.AKS_MACHINE_TYPE.name()))
+        .thenReturn(ContainerServiceVMSizeTypes.STANDARD_A2_V2.toString());
+    when(mockParametersResolver.getValue(
+            CromwellBaseResourcesFactory.ParametersNames.AKS_NODE_COUNT.name()))
+        .thenReturn("1");
+    when(mockParametersResolver.getValue(
+            CromwellBaseResourcesFactory.ParametersNames.AKS_AUTOSCALING_ENABLED.name()))
+        .thenReturn("false");
+  }
+
+  private void setupArmManagersForDoStep() {
+    setupMocksForEnablingWorkloadIdentity();
+    when(mockKubernetesCluster.id()).thenReturn(RESOURCE_ID);
+    when(mockK8sDefinitionStageWithCreate.create()).thenReturn(mockKubernetesCluster);
+    when(mockK8sDefinitionStageWithCreate.withTags(tagsCaptor.capture()))
+        .thenReturn(mockK8sDefinitionStageWithCreate);
+    when(mockK8sDefinitionStageWithCreate.withAddOnProfiles(addonProfileCaptor.capture()))
+        .thenReturn(mockK8sDefinitionStageWithCreate);
+    when(mockK8sDefinition.withDnsPrefix(anyString())).thenReturn(mockK8sDefinitionStageWithCreate);
+    when(mockK8sAPDefinitionStagesWithAttach.attach()).thenReturn(mockK8sDefinition);
+    when(mockK8sAPDefinitionStagesWithAttach.withVirtualNetwork(anyString(), anyString()))
+        .thenReturn(mockK8sAPDefinitionStagesWithAttach);
+    when(mockK8sAPDefinitionStagesWithAttach.withAgentPoolMode(eq(AgentPoolMode.SYSTEM)))
+        .thenReturn(mockK8sAPDefinitionStagesWithAttach);
+    when(mockK8sAPDefinitionStagesMachineCount.withAgentPoolVirtualMachineCount(anyInt()))
+        .thenReturn(mockK8sAPDefinitionStagesWithAttach);
+    when(mockK8sAPDefinitionStagesBlank.withVirtualMachineSize(
+            any(ContainerServiceVMSizeTypes.class)))
+        .thenReturn(mockK8sAPDefinitionStagesMachineCount);
+    when(mockK8sDefinitionStageWithCreate.defineAgentPool(anyString()))
+        .thenReturn(mockK8sAPDefinitionStagesBlank);
+    when(mockK8sDefinitionStageWithLinuxRootUsername.withSystemAssignedManagedServiceIdentity())
+        .thenReturn(mockK8sDefinitionStageWithCreate);
+    when(mockK8sDefinitionStageWithVersion.withDefaultVersion())
+        .thenReturn(mockK8sDefinitionStageWithLinuxRootUsername);
+    when(mockK8sDefinitionStageWithGroup.withExistingResourceGroup(anyString()))
+        .thenReturn(mockK8sDefinitionStageWithVersion);
+    when(mockK8sDefinitionStageBlank.withRegion(anyString()))
+        .thenReturn(mockK8sDefinitionStageWithGroup);
+    when(mockKubernetesClusters.define(anyString())).thenReturn(mockK8sDefinitionStageBlank);
+    when(mockAzureResourceManager.kubernetesClusters()).thenReturn(mockKubernetesClusters);
+    when(mockArmManagers.azureResourceManager()).thenReturn(mockAzureResourceManager);
+  }
+
+  private void setupMocksForEnablingWorkloadIdentity() {
+    KubernetesCluster.Update mockK8sUpdate = mock(KubernetesCluster.Update.class);
+    ManagedClusterInner mockManagedClusterInner = mock(ManagedClusterInner.class);
+    ManagedClusterSecurityProfile mockManagedClusterSecurityProfile =
+        mock(ManagedClusterSecurityProfile.class);
+    ManagedClusterOidcIssuerProfile mockManagedClusterOidcIssuerProfile =
+        mock(ManagedClusterOidcIssuerProfile.class);
+    when(mockKubernetesCluster.update()).thenReturn(mockK8sUpdate);
+    when(mockManagedClusterInner.securityProfile()).thenReturn(mockManagedClusterSecurityProfile);
+    when(mockManagedClusterOidcIssuerProfile.issuerUrl()).thenReturn("issuerUrl");
+    when(mockManagedClusterInner.oidcIssuerProfile())
+        .thenReturn(mockManagedClusterOidcIssuerProfile);
+    when(mockKubernetesCluster.innerModel()).thenReturn(mockManagedClusterInner);
+  }
+
+  private static Stream<Arguments> workingParametersProvider() {
+    return Stream.of(
+        // intentionally return empty map, to check required parameter validation
+        Arguments.of(
+            Map.of(
+                CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_WORKSPACE_ID,
+                "logAnalyticsWorkspaceId")),
+        Arguments.of(Map.of(CreateVnetStep.VNET_ID, "vNetId")));
+  }
+}


### PR DESCRIPTION
K8s cost optimization settings requires following parameter 'useAADAuth'=true. The cost optimization settings won't be provisioned correctly without this parameter. At the same time this parameter breaks K8s monitoring. So, temporarily disabling cost optimization step to unblock K9s monitoring.

This PR:
-temporarily remove K8s cost optimization step from LZ flight.