### PR TITLE
WOR-1164 Mitigate deletion of virtualNetworkLink

### DIFF
--- a/service/src/main/java/bio/terra/landingzone/common/VirtualNetworkLinkResourceHelper.java
+++ b/service/src/main/java/bio/terra/landingzone/common/VirtualNetworkLinkResourceHelper.java
@@ -1,0 +1,26 @@
+package bio.terra.landingzone.common;
+
+import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
+
+public class VirtualNetworkLinkResourceHelper {
+  private VirtualNetworkLinkResourceHelper() {}
+
+  public static void delete(ArmManagers armManagers, String resourceId) {
+    var idParts = resourceId.split("/");
+    if (idParts.length != 11) {
+      throw new IllegalArgumentException(
+          String.format("Invalid vnet link resourceId: %s", resourceId));
+    }
+    var mrgName = idParts[4];
+    var privateDnsZoneName = idParts[8];
+    var vnetLinkName = idParts[10];
+
+    armManagers
+        .azureResourceManager()
+        .privateDnsZones()
+        .manager()
+        .serviceClient()
+        .getVirtualNetworkLinks()
+        .delete(mrgName, privateDnsZoneName, vnetLinkName);
+  }
+}

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/management/ResourcesDeleteManager.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/management/ResourcesDeleteManager.java
@@ -1,5 +1,6 @@
 package bio.terra.landingzone.library.landingzones.management;
 
+import bio.terra.landingzone.common.VirtualNetworkLinkResourceHelper;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
 import bio.terra.landingzone.library.landingzones.management.deleterules.LandingZoneRuleDeleteException;
@@ -161,11 +162,15 @@ public class ResourcesDeleteManager {
               });
     }
 
-    armManagers
-        .azureResourceManager()
-        .genericResources()
-        .deleteById(resourceToDelete.resource().id());
-
+    if (resourceToDelete.resource().id().contains("virtualNetworkLinks")) {
+      // this is temporary solution since generic deletion is failing for this type of resource
+      VirtualNetworkLinkResourceHelper.delete(armManagers, resourceToDelete.resource().id());
+    } else {
+      armManagers
+          .azureResourceManager()
+          .genericResources()
+          .deleteById(resourceToDelete.resource().id());
+    }
     logger.info("Resource deleted. id:{}", resourceToDelete.resource().id());
 
     return resourceToDelete.resource();

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateVirtualNetworkLinkStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateVirtualNetworkLinkStep.java
@@ -1,5 +1,6 @@
 package bio.terra.landingzone.stairway.flight.create.resource.step;
 
+import bio.terra.landingzone.common.VirtualNetworkLinkResourceHelper;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerator;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
@@ -79,22 +80,7 @@ public class CreateVirtualNetworkLinkStep extends BaseResourceCreateStep {
 
   @Override
   protected void deleteResource(String resourceId) {
-    var idParts = resourceId.split("/");
-    if (idParts.length != 11) {
-      throw new IllegalArgumentException(
-          String.format("Invalid vnet link resourceId: %s", resourceId));
-    }
-    var mrgName = idParts[4];
-    var privateDnsZoneName = idParts[8];
-    var vnetLinkName = idParts[10];
-
-    armManagers
-        .azureResourceManager()
-        .privateDnsZones()
-        .manager()
-        .serviceClient()
-        .getVirtualNetworkLinks()
-        .delete(mrgName, privateDnsZoneName, vnetLinkName);
+    VirtualNetworkLinkResourceHelper.delete(armManagers, resourceId);
   }
 
   @Override


### PR DESCRIPTION
This PR uses resource specific deletion instead of generic one. This is temporary solution until the issue is fixed in Java SDK.