### PR TITLE
WOR-1147 Enable K8s cost optimization settings for monitoring

### DIFF
--- a/service/src/main/java/bio/terra/landingzone/common/utils/HttpResponseUtils.java
+++ b/service/src/main/java/bio/terra/landingzone/common/utils/HttpResponseUtils.java
@@ -1,0 +1,14 @@
+package bio.terra.landingzone.common.utils;
+
+import org.springframework.http.HttpStatus;
+
+public class HttpResponseUtils {
+  private HttpResponseUtils() {}
+
+  public static boolean isRetryable(int httpStatusCode) {
+    return httpStatusCode == HttpStatus.INTERNAL_SERVER_ERROR.value()
+        || httpStatusCode == HttpStatus.BAD_GATEWAY.value()
+        || httpStatusCode == HttpStatus.SERVICE_UNAVAILABLE.value()
+        || httpStatusCode == HttpStatus.GATEWAY_TIMEOUT.value();
+  }
+}

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/CromwellStepsDefinitionProvider.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/CromwellStepsDefinitionProvider.java
@@ -6,6 +6,7 @@ import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfi
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
 import bio.terra.landingzone.library.landingzones.definition.factories.validation.InputParametersValidationFactory;
+import bio.terra.landingzone.stairway.flight.create.resource.step.CreateAksCostOptimizationDataCollectionRulesStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateAksStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateAppInsightsStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateBatchAccountStep;
@@ -23,6 +24,7 @@ import bio.terra.landingzone.stairway.flight.create.resource.step.CreateStorageA
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateStorageAuditLogSettingsStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateVirtualNetworkLinkStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.CreateVnetStep;
+import bio.terra.landingzone.stairway.flight.create.resource.step.EnableAksContainerInsightsStep;
 import bio.terra.landingzone.stairway.flight.create.resource.step.EnableAksContainerLogV2Step;
 import bio.terra.landingzone.stairway.flight.create.resource.step.GetManagedResourceGroupInfo;
 import bio.terra.landingzone.stairway.flight.create.resource.step.KubernetesClientProviderImpl;
@@ -107,10 +109,15 @@ public class CromwellStepsDefinitionProvider implements StepsDefinitionProvider 
             new CreateAppInsightsStep(armManagers, parametersResolver, resourceNameProvider),
             RetryRules.cloud()),
         Pair.of(
+            new CreateAksCostOptimizationDataCollectionRulesStep(
+                armManagers, parametersResolver, resourceNameProvider),
+            RetryRules.cloud()),
+        Pair.of(
             new EnableAksContainerLogV2Step(
                 armManagers,
                 new KubernetesClientProviderImpl(),
                 new AksConfigMapFileReaderImpl(EnableAksContainerLogV2Step.CONFIG_MAP_PATH)),
-            RetryRules.cloud()));
+            RetryRules.cloud()),
+        Pair.of(new EnableAksContainerInsightsStep(armManagers), RetryRules.cloud()));
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksCostOptimizationDataCollectionRulesStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksCostOptimizationDataCollectionRulesStep.java
@@ -5,6 +5,7 @@ import bio.terra.landingzone.library.landingzones.definition.ResourceNameGenerat
 import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
 import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
 import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
+import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
 import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
 import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
@@ -17,6 +18,7 @@ import com.azure.resourcemanager.monitor.models.DataCollectionRuleDataSources;
 import com.azure.resourcemanager.monitor.models.DataCollectionRuleDestinations;
 import com.azure.resourcemanager.monitor.models.DataFlow;
 import com.azure.resourcemanager.monitor.models.ExtensionDataSource;
+import com.azure.resourcemanager.monitor.models.KnownDataCollectionRuleResourceKind;
 import com.azure.resourcemanager.monitor.models.KnownDataFlowStreams;
 import com.azure.resourcemanager.monitor.models.KnownExtensionDataSourceStreams;
 import com.azure.resourcemanager.monitor.models.KnownSyslogDataSourceFacilityNames;
@@ -44,15 +46,6 @@ import org.springframework.http.HttpStatus;
  * will be included or excluded based on the namespaceFilteringMode. This parameter is not included
  * into current configuration since namespaceFilteringMode is set to Off. But can be added later by
  * adding 'namespaces' field into DataCollectionSettings.
- */
-
-/**
- * **********************************!!! WARNING !!!**********************************
- *
- * <p>This step is currently excluded from LZ flight because it breaks K8s monitoring. The cost
- * optimization settings requires following parameter 'useAADAuth' set to true, but at the same time
- * setting this value breaks K8s monitoring. This step is temporarily disabled until we find
- * workaround or proper resolution.
  */
 public class CreateAksCostOptimizationDataCollectionRulesStep extends BaseResourceCreateStep {
   public static final String AKS_COST_OPTIMIZATION_DATA_COLLECTION_RULE_ID =
@@ -150,7 +143,12 @@ public class CreateAksCostOptimizationDataCollectionRulesStep extends BaseResour
     // "MSCI-k8sRegion-k8sName"
     // but this behavior looks like Azure portal limitation since this rule is created implicitly
     // and user doesn't set it.
-    var dataCollectionRuleName = resourceNameProvider.getName(getResourceType());
+    var aksResource =
+        getParameterOrThrow(
+            context.getWorkingMap(), CreateAksStep.AKS_RESOURCE_KEY, LandingZoneResource.class);
+    // var dataCollectionRuleName = resourceNameProvider.getName(getResourceType());
+    var dataCollectionRuleName =
+        getRuleName(aksResource.region(), aksResource.resourceName().orElseThrow());
     try {
       var dataCollectionRule =
           armManagers
@@ -166,6 +164,9 @@ public class CreateAksCostOptimizationDataCollectionRulesStep extends BaseResour
       context
           .getWorkingMap()
           .put(AKS_COST_OPTIMIZATION_DATA_COLLECTION_RULE_ID, dataCollectionRule.getValue().id());
+      logger.info(
+          "Data collection rule for cost optimization settings created. Rule id={}",
+          dataCollectionRule.getValue().id());
       return dataCollectionRule.getValue().id();
     } catch (ManagementException e) {
       if (e.getResponse() != null
@@ -215,7 +216,9 @@ public class CreateAksCostOptimizationDataCollectionRulesStep extends BaseResour
                         new ExtensionDataSource()
                             .withName("ContainerInsightsExtension")
                             .withStreams(
-                                List.of(KnownExtensionDataSourceStreams.MICROSOFT_INSIGHTS_METRICS))
+                                List.of(
+                                    KnownExtensionDataSourceStreams.fromString(
+                                        "Microsoft-ContainerInsights-Group-Default")))
                             .withExtensionName("ContainerInsights")
                             .withExtensionSettings(defaultExtensionSettings)))
                 .withSyslog(
@@ -237,10 +240,12 @@ public class CreateAksCostOptimizationDataCollectionRulesStep extends BaseResour
                 new DataFlow()
                     .withStreams(
                         List.of(
-                            KnownDataFlowStreams.MICROSOFT_INSIGHTS_METRICS,
+                            KnownDataFlowStreams.fromString(
+                                "Microsoft-ContainerInsights-Group-Default"),
                             KnownDataFlowStreams.MICROSOFT_SYSLOG))
                     .withDestinations(List.of(DESTINATION_NAME))))
         .withLocation(regionName)
+        .withKind(KnownDataCollectionRuleResourceKind.LINUX)
         .withTags(
             Map.of(
                 LandingZoneTagKeys.LANDING_ZONE_ID.toString(),
@@ -263,5 +268,9 @@ public class CreateAksCostOptimizationDataCollectionRulesStep extends BaseResour
     return KnownSyslogDataSourceFacilityNames.values().stream()
         .filter(v -> !v.equals(KnownSyslogDataSourceFacilityNames.ASTERISK))
         .toList();
+  }
+
+  private static String getRuleName(String aksRegion, String aksName) {
+    return String.format("MSCI-%s-%s", aksRegion, aksName);
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksCostOptimizationDataCollectionRulesStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksCostOptimizationDataCollectionRulesStep.java
@@ -139,14 +139,13 @@ public class CreateAksCostOptimizationDataCollectionRulesStep extends BaseResour
 
   private String createRule(
       UUID landingZoneId, String logAnalyticsWorkspaceId, FlightContext context) {
-    // if this is created via portal name of the rule has the following format by default:
-    // "MSCI-k8sRegion-k8sName"
-    // but this behavior looks like Azure portal limitation since this rule is created implicitly
-    // and user doesn't set it.
     var aksResource =
         getParameterOrThrow(
             context.getWorkingMap(), CreateAksStep.AKS_RESOURCE_KEY, LandingZoneResource.class);
-    // var dataCollectionRuleName = resourceNameProvider.getName(getResourceType());
+    // Following convention for rule name as described here at the limitation section
+    // https://learn.microsoft.com/en-us/azure/azure-monitor/containers/container-insights-enable-aks?tabs=azure-cli
+    // if this is created via portal name of the rule has the following format by default:
+    // "MSCI-k8sRegion-k8sName".
     var dataCollectionRuleName =
         getRuleName(aksResource.region(), aksResource.resourceName().orElseThrow());
     try {

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksStep.java
@@ -44,11 +44,6 @@ public class CreateAksStep extends BaseResourceCreateStep {
     UUID landingZoneId =
         getParameterOrThrow(
             context.getInputParameters(), LandingZoneFlightMapKeys.LANDING_ZONE_ID, UUID.class);
-    var logAnalyticsWorkspaceId =
-        getParameterOrThrow(
-            context.getWorkingMap(),
-            CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_WORKSPACE_ID,
-            String.class);
     var vNetId = getParameterOrThrow(context.getWorkingMap(), CreateVnetStep.VNET_ID, String.class);
 
     var aksName = resourceNameProvider.getName(getResourceType());

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksStep.java
@@ -14,11 +14,9 @@ import bio.terra.stairway.FlightContext;
 import com.azure.resourcemanager.containerservice.models.AgentPoolMode;
 import com.azure.resourcemanager.containerservice.models.ContainerServiceVMSizeTypes;
 import com.azure.resourcemanager.containerservice.models.KubernetesCluster;
-import com.azure.resourcemanager.containerservice.models.ManagedClusterAddonProfile;
 import com.azure.resourcemanager.containerservice.models.ManagedClusterOidcIssuerProfile;
 import com.azure.resourcemanager.containerservice.models.ManagedClusterSecurityProfile;
 import com.azure.resourcemanager.containerservice.models.ManagedClusterSecurityProfileWorkloadIdentity;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -52,13 +50,6 @@ public class CreateAksStep extends BaseResourceCreateStep {
             CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_WORKSPACE_ID,
             String.class);
     var vNetId = getParameterOrThrow(context.getWorkingMap(), CreateVnetStep.VNET_ID, String.class);
-
-    final Map<String, ManagedClusterAddonProfile> addonProfileMap = new HashMap<>();
-    addonProfileMap.put(
-        "omsagent",
-        new ManagedClusterAddonProfile()
-            .withEnabled(true)
-            .withConfig(Map.of("logAnalyticsWorkspaceResourceID", logAnalyticsWorkspaceId)));
 
     var aksName = resourceNameProvider.getName(getResourceType());
     var aksPartial =
@@ -100,7 +91,6 @@ public class CreateAksStep extends BaseResourceCreateStep {
         aksPartial
             .attach()
             .withDnsPrefix(resourceNameProvider.getName(getResourceType() + DNS_SUFFIX_KEY))
-            .withAddOnProfiles(addonProfileMap)
             .withTags(
                 Map.of(
                     LandingZoneTagKeys.LANDING_ZONE_ID.toString(),

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/EnableAksContainerInsightsStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/EnableAksContainerInsightsStep.java
@@ -17,13 +17,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This step turns on Container insights (monitoring) for AKS by applying specific profile. We know
- * that earlier ContainerInsight was created as a result of enabling monitoring feature in AKS. And
- * usage of the following option "useAADAuth=true" results in AKS monitoring/logging issue as
- * ContainerInsight wasn't created in a specific MRG. So, that ContainerInsight was part of legacy
- * solution, and now we need to use "useAADAuth=true" option instead. But we need to enable
- * container insight separately from AKS creation. Also, container insight should be enabled as a
- * last step once all the logging configuration/rules are ready.
+ * This step turns on Container insights (monitoring) for AKS by applying the specific add-on
+ * profile, specifying "useAADAuth=true". Container insights must be enabled after AKS creation, and
+ * after the AKS monitoring configuration is created (for instance data collection rule and rule
+ * association in case of cost optimization settings or ContainerLogV2). Attempting to enable
+ * container insights at the time of AKS creation resulted in broken AKS monitoring.
  */
 public class EnableAksContainerInsightsStep implements Step {
   private static final Logger logger =

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/EnableAksContainerInsightsStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/EnableAksContainerInsightsStep.java
@@ -59,13 +59,10 @@ public class EnableAksContainerInsightsStep implements Step {
                     logAnalyticsWorkspaceId,
                     "useAADAuth",
                     "true")));
-
     try {
       var aks = armManagers.azureResourceManager().kubernetesClusters().getById(aksId);
       KubernetesCluster.Update aksToUpdate = aks.update();
       aksToUpdate.withAddOnProfiles(addonProfileMap).apply();
-      // aksToUpdate.apply();
-      // aks.refresh();
       logger.info("Container insights for AKS with id='{}' has been enabled.", aksId);
     } catch (ManagementException e) {
       if (HttpResponseUtils.isRetryable(e.getResponse().getStatusCode())) {
@@ -81,7 +78,7 @@ public class EnableAksContainerInsightsStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext context) throws InterruptedException {
-    // no need disable container insights
+    // no need to disable container insights
     return StepResult.getStepResultSuccess();
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/EnableAksContainerInsightsStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/EnableAksContainerInsightsStep.java
@@ -1,0 +1,87 @@
+package bio.terra.landingzone.stairway.flight.create.resource.step;
+
+import bio.terra.landingzone.common.utils.HttpResponseUtils;
+import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
+import bio.terra.landingzone.stairway.flight.utils.FlightUtils;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.stairway.exception.RetryException;
+import com.azure.core.management.exception.ManagementException;
+import com.azure.resourcemanager.containerservice.models.KubernetesCluster;
+import com.azure.resourcemanager.containerservice.models.ManagedClusterAddonProfile;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This step turns on Container insights (monitoring) for AKS by applying specific profile. We know
+ * that earlier ContainerInsight was created as a result of enabling monitoring feature in AKS. And
+ * usage of the following option "useAADAuth=true" results in AKS monitoring/logging issue as
+ * ContainerInsight wasn't created in a specific MRG. So, that ContainerInsight was part of legacy
+ * solution, and now we need to use "useAADAuth=true" option instead. But we need to enable
+ * container insight separately from AKS creation. Also, container insight should be enabled as a
+ * last step once all the logging configuration/rules are ready.
+ */
+public class EnableAksContainerInsightsStep implements Step {
+  private static final Logger logger =
+      LoggerFactory.getLogger(EnableAksContainerInsightsStep.class);
+
+  private final ArmManagers armManagers;
+
+  public EnableAksContainerInsightsStep(ArmManagers armManagers) {
+    this.armManagers = armManagers;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    FlightUtils.validateRequiredEntries(
+        context.getWorkingMap(), CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_WORKSPACE_ID);
+    var logAnalyticsWorkspaceId =
+        FlightUtils.getRequired(
+            context.getWorkingMap(),
+            CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_WORKSPACE_ID,
+            String.class);
+    FlightUtils.validateRequiredEntries(context.getWorkingMap(), CreateAksStep.AKS_ID);
+    var aksId =
+        FlightUtils.getRequired(context.getWorkingMap(), CreateAksStep.AKS_ID, String.class);
+
+    final Map<String, ManagedClusterAddonProfile> addonProfileMap = new HashMap<>();
+    addonProfileMap.put(
+        "omsagent",
+        new ManagedClusterAddonProfile()
+            .withEnabled(true)
+            .withConfig(
+                Map.of(
+                    "logAnalyticsWorkspaceResourceID",
+                    logAnalyticsWorkspaceId,
+                    "useAADAuth",
+                    "true")));
+
+    try {
+      var aks = armManagers.azureResourceManager().kubernetesClusters().getById(aksId);
+      KubernetesCluster.Update aksToUpdate = aks.update();
+      aksToUpdate.withAddOnProfiles(addonProfileMap).apply();
+      // aksToUpdate.apply();
+      // aks.refresh();
+      logger.info("Container insights for AKS with id='{}' has been enabled.", aksId);
+    } catch (ManagementException e) {
+      if (HttpResponseUtils.isRetryable(e.getResponse().getStatusCode())) {
+        logger.error("Failed attempt to enable container insights for AKS with id='{}'", aksId);
+        return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
+      } else {
+        logger.error("Failed to enable container insights for AKS with id='{}'", aksId);
+        return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
+      }
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    // no need disable container insights
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/EnableAksContainerLogV2Step.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/EnableAksContainerLogV2Step.java
@@ -2,6 +2,7 @@ package bio.terra.landingzone.stairway.flight.create.resource.step;
 
 import bio.terra.landingzone.common.k8s.configmap.reader.AksConfigMapReader;
 import bio.terra.landingzone.common.k8s.configmap.reader.AksConfigMapReaderException;
+import bio.terra.landingzone.common.utils.HttpResponseUtils;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
 import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
@@ -16,7 +17,6 @@ import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
 
 /**
  * This class implements functionality to apply specific ConfigMap to AKS to enable ContainerLogV2
@@ -99,9 +99,6 @@ public class EnableAksContainerLogV2Step implements Step {
   }
 
   private boolean isK8sApiRetryableError(int httpStatusCode) {
-    return httpStatusCode == HttpStatus.INTERNAL_SERVER_ERROR.value()
-        || httpStatusCode == HttpStatus.BAD_GATEWAY.value()
-        || httpStatusCode == HttpStatus.SERVICE_UNAVAILABLE.value()
-        || httpStatusCode == HttpStatus.GATEWAY_TIMEOUT.value();
+    return HttpResponseUtils.isRetryable(httpStatusCode);
   }
 }

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
@@ -168,7 +168,7 @@ public class CreateLandingZoneResourcesFlightIntegrationTest extends BaseIntegra
                   resources,
                   hasSize(
                       AggregateLandingZoneResourcesStep.deployedResourcesKeys.size()
-                          + 1 /*magic number which represents data collection rules which probably should not be tagged as shared resources*/));
+                          + 2 /*magic number which represents data collection rules which probably should not be tagged as shared resources*/));
             });
     var flightState = retrieveFlightState(jobId.toString());
     assertThat(flightState.getFlightStatus(), is(FlightStatus.SUCCESS));
@@ -177,9 +177,7 @@ public class CreateLandingZoneResourcesFlightIntegrationTest extends BaseIntegra
     // (these can silently fail to create, so we are making a explicit check here)
     assertDiagnosticSettings(
         CreateStorageAuditLogSettingsStep.STORAGE_AUDIT_LOG_SETTINGS_KEY, flightState);
-    // disabling this validation because current data collection rule is currently disabled
-    // due to k8s monitoring issue. Jira - WOR-1147
-    // assertAksCostOptimizedDataCollectionRule(flightState);
+    assertAksCostOptimizedDataCollectionRule(flightState);
     assertContainerLogV2();
     testCannotDeleteLandingZoneWithDependencies();
   }

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksStepTest.java
@@ -206,10 +206,6 @@ class CreateAksStepTest extends BaseStepTest {
   private static Stream<Arguments> workingParametersProvider() {
     return Stream.of(
         // intentionally return empty map, to check required parameter validation
-        Arguments.of(
-            Map.of(
-                CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_WORKSPACE_ID,
-                "logAnalyticsWorkspaceId")),
-        Arguments.of(Map.of(CreateVnetStep.VNET_ID, "vNetId")));
+        Arguments.of(Map.of()));
   }
 }

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/EnableAksContainerInsightsStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/EnableAksContainerInsightsStepTest.java
@@ -1,0 +1,178 @@
+package bio.terra.landingzone.stairway.flight.create.resource.step;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import bio.terra.landingzone.stairway.flight.FlightTestUtils;
+import bio.terra.landingzone.stairway.flight.exception.MissingRequiredFieldsException;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import com.azure.core.http.HttpResponse;
+import com.azure.core.management.exception.ManagementException;
+import com.azure.resourcemanager.containerservice.models.KubernetesCluster;
+import com.azure.resourcemanager.containerservice.models.KubernetesClusters;
+import com.azure.resourcemanager.containerservice.models.ManagedClusterAddonProfile;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("unit")
+class EnableAksContainerInsightsStepTest extends BaseStepTest {
+  EnableAksContainerInsightsStep testStep;
+
+  @Mock KubernetesClusters mockKubernetesClusters;
+  @Mock KubernetesCluster mockKubernetesCluster;
+  @Mock KubernetesCluster.Update mockKubernetesClusterUpdate;
+
+  @Captor ArgumentCaptor<String> aksIdCaptor;
+  @Captor private ArgumentCaptor<Map<String, ManagedClusterAddonProfile>> addonProfileCaptor;
+
+  @BeforeEach
+  void setup() {
+    testStep = new EnableAksContainerInsightsStep(mockArmManagers);
+  }
+
+  @Test
+  void doStepSuccess() throws InterruptedException {
+    final String aksId = "aksId";
+    setupFlightContext(
+        mockFlightContext,
+        null,
+        Map.of(
+            CreateAksStep.AKS_ID,
+            aksId,
+            CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_WORKSPACE_ID,
+            "logAnalyticsWorkspaceId"));
+    mockArmManagers();
+
+    StepResult stepResult = testStep.doStep(mockFlightContext);
+
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verifyAddonProfile(addonProfileCaptor.getValue());
+  }
+
+  @Test
+  void doStepFailedWithRetryableError() throws InterruptedException {
+    final String aksId = "aksId";
+    setupFlightContext(
+        mockFlightContext,
+        null,
+        Map.of(
+            CreateAksStep.AKS_ID,
+            aksId,
+            CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_WORKSPACE_ID,
+            "logAnalyticsWorkspaceId"));
+    mockArmManagers();
+
+    var exception = mockRetryableException();
+    doThrow(exception).when(mockKubernetesClusterUpdate).apply();
+
+    StepResult stepResult = testStep.doStep(mockFlightContext);
+
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_RETRY));
+  }
+
+  @Test
+  void doStepFailedWithNonRetryableError() throws InterruptedException {
+    final String aksId = "aksId";
+    setupFlightContext(
+        mockFlightContext,
+        null,
+        Map.of(
+            CreateAksStep.AKS_ID,
+            aksId,
+            CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_WORKSPACE_ID,
+            "logAnalyticsWorkspaceId"));
+    mockArmManagers();
+
+    var exception = mockNonRetryableException();
+    doThrow(exception).when(mockKubernetesClusterUpdate).apply();
+
+    StepResult stepResult = testStep.doStep(mockFlightContext);
+
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+  }
+
+  @ParameterizedTest
+  @MethodSource("workingParametersProvider")
+  void doStepMissingWorkingParameterThrowsException(Map<String, Object> workingParameters) {
+    FlightMap flightMapWorkingParameters =
+        FlightTestUtils.prepareFlightWorkingParameters(workingParameters);
+    when(mockFlightContext.getWorkingMap()).thenReturn(flightMapWorkingParameters);
+
+    assertThrows(MissingRequiredFieldsException.class, () -> testStep.doStep(mockFlightContext));
+  }
+
+  @Test
+  void undoStepSuccess() throws InterruptedException {
+    // verify step does anything except returning success
+    assertThat(
+        testStep.undoStep(mockFlightContext).getStepStatus(),
+        equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verifyNoInteractions(mockArmManagers);
+  }
+
+  private void mockArmManagers() {
+    when(mockKubernetesClusterUpdate.withAddOnProfiles(addonProfileCaptor.capture()))
+        .thenReturn(mockKubernetesClusterUpdate);
+    when(mockKubernetesCluster.update()).thenReturn(mockKubernetesClusterUpdate);
+    when(mockKubernetesClusters.getById(aksIdCaptor.capture())).thenReturn(mockKubernetesCluster);
+    when(mockAzureResourceManager.kubernetesClusters()).thenReturn(mockKubernetesClusters);
+    when(mockArmManagers.azureResourceManager()).thenReturn(mockAzureResourceManager);
+  }
+
+  private ManagementException mockManagementException(int statusCode) {
+    var azureException = mock(ManagementException.class);
+    var httpResponse = mock(HttpResponse.class);
+    when(httpResponse.getStatusCode()).thenReturn(statusCode);
+    when(azureException.getResponse()).thenReturn(httpResponse);
+    return azureException;
+  }
+
+  private ManagementException mockNonRetryableException() {
+    return mockManagementException(HttpStatus.LOOP_DETECTED.value());
+  }
+
+  private ManagementException mockRetryableException() {
+    return mockManagementException(HttpStatus.SERVICE_UNAVAILABLE.value());
+  }
+
+  private void verifyAddonProfile(Map<String, ManagedClusterAddonProfile> addonProfile) {
+    ManagedClusterAddonProfile profile = addonProfile.get("omsagent");
+    assertNotNull(profile);
+    assertTrue(profile.enabled());
+    assertTrue(profile.config().containsKey("useAADAuth"), "'useAADAuth' should be set.");
+    assertTrue(
+        profile.config().containsKey("logAnalyticsWorkspaceResourceID"),
+        "'logAnalyticsWorkspaceResourceID' should be used.");
+  }
+
+  private static Stream<Arguments> workingParametersProvider() {
+    return Stream.of(
+        Arguments.of(Map.of(CreateAksStep.AKS_ID, "aksId")),
+        Arguments.of(
+            Map.of(
+                CreateLogAnalyticsWorkspaceStep.LOG_ANALYTICS_WORKSPACE_ID,
+                "logAnalyticsWorkspaceId")));
+  }
+}

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/ResourceStepFixture.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/ResourceStepFixture.java
@@ -1,7 +1,10 @@
 package bio.terra.landingzone.stairway.flight.create.resource.step;
 
+import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
 import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
 import bio.terra.profile.model.ProfileModel;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 public class ResourceStepFixture {
@@ -17,5 +20,10 @@ public class ResourceStepFixture {
         .managedResourceGroupId("defaultManagedResourceGroupId")
         .subscriptionId(UUID.randomUUID())
         .tenantId(UUID.randomUUID());
+  }
+
+  public static LandingZoneResource createAksLandingZoneResource(String aksId, String aksName) {
+    return new LandingZoneResource(
+        aksId, "aks", Map.of(), "eastus", Optional.of(aksName), Optional.empty());
   }
 }


### PR DESCRIPTION
This PR turn on K8s cost optimization settings for monitoring. Especially it 1) sets monitoring interval 30 minutes long and 2) turn off namespace filtering 3) enables syslog collection.

In general, to achieve this we need to create: 1) data collection rule 2) data collection rule association and 3) enable K8s monitoring. To enable monitoring, we need to apply special "omsagent" profile which points to a certain log analytics workspace and has following property "useAADAuth=true". Earlier we applied this profile during K8s creation. But it turns out that using this parameter "useAADAuth=true" breaks K8s logging. So, it was removed and as a result we disable this cost optimization settings. It turns out that this parameter is required, but instead we need to enable k8s monitoring later once K8s cluster is already created.