### PR TITLE
[WOR-1218] Use AKS AAD integration

### DIFF
--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactory.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactory.java
@@ -418,10 +418,6 @@ public class CromwellBaseResourcesFactory extends ArmClientsDefinitionFactory {
       defaultValues.put(
           StorageAccountBlobCorsParametersNames.STORAGE_ACCOUNT_BLOB_CORS_MAX_AGE.name(),
           STORAGE_ACCOUNT_BLOB_CORS_MAX_AGE_DEFAULT);
-      defaultValues.put(
-          ParametersNames.AKS_AAD_PROFILE_USER_GROUP_ID.name(),
-          "00000000-0000-0000-0000-000000000000");
-
       return defaultValues;
     }
   }

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactory.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactory.java
@@ -420,7 +420,7 @@ public class CromwellBaseResourcesFactory extends ArmClientsDefinitionFactory {
           STORAGE_ACCOUNT_BLOB_CORS_MAX_AGE_DEFAULT);
       defaultValues.put(
           ParametersNames.AKS_AAD_PROFILE_USER_GROUP_ID.name(),
-          "0f257889-b344-4f34-ac5a-b684fc6b02e5");
+          "00000000-0000-0000-0000-000000000000");
 
       return defaultValues;
     }

--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactory.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/CromwellBaseResourcesFactory.java
@@ -98,6 +98,7 @@ public class CromwellBaseResourcesFactory extends ArmClientsDefinitionFactory {
     AKS_AUTOSCALING_ENABLED,
     AKS_AUTOSCALING_MIN,
     AKS_AUTOSCALING_MAX,
+    AKS_AAD_PROFILE_USER_GROUP_ID,
     STORAGE_ACCOUNT_SKU_TYPE
   }
 
@@ -417,6 +418,10 @@ public class CromwellBaseResourcesFactory extends ArmClientsDefinitionFactory {
       defaultValues.put(
           StorageAccountBlobCorsParametersNames.STORAGE_ACCOUNT_BLOB_CORS_MAX_AGE.name(),
           STORAGE_ACCOUNT_BLOB_CORS_MAX_AGE_DEFAULT);
+      defaultValues.put(
+          ParametersNames.AKS_AAD_PROFILE_USER_GROUP_ID.name(),
+          "0f257889-b344-4f34-ac5a-b684fc6b02e5");
+
       return defaultValues;
     }
   }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/LandingZoneDefaultParameters.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/LandingZoneDefaultParameters.java
@@ -78,6 +78,9 @@ public class LandingZoneDefaultParameters {
     defaultValues.put(
         CromwellBaseResourcesFactory.ParametersNames.STORAGE_ACCOUNT_SKU_TYPE.name(),
         StorageAccountSkuType.STANDARD_LRS.name().toString());
+    defaultValues.put(
+        CromwellBaseResourcesFactory.ParametersNames.AKS_AAD_PROFILE_USER_GROUP_ID.name(),
+        "0f257889-b344-4f34-ac5a-b684fc6b02e5");
     return defaultValues;
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/LandingZoneDefaultParameters.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/LandingZoneDefaultParameters.java
@@ -80,7 +80,7 @@ public class LandingZoneDefaultParameters {
         StorageAccountSkuType.STANDARD_LRS.name().toString());
     defaultValues.put(
         CromwellBaseResourcesFactory.ParametersNames.AKS_AAD_PROFILE_USER_GROUP_ID.name(),
-        "0f257889-b344-4f34-ac5a-b684fc6b02e5");
+        "00000000-0000-0000-0000-000000000000");
     return defaultValues;
   }
 }

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksStep.java
@@ -56,6 +56,10 @@ public class CreateAksStep extends BaseResourceCreateStep {
             .withExistingResourceGroup(getMRGName(context))
             .withDefaultVersion()
             .withSystemAssignedManagedServiceIdentity()
+            .withAzureActiveDirectoryGroup(
+                parametersResolver.getValue(
+                    CromwellBaseResourcesFactory.ParametersNames.AKS_AAD_PROFILE_USER_GROUP_ID
+                        .name()))
             .defineAgentPool(resourceNameProvider.getName(getResourceType() + POOL_SUFFIX_KEY))
             .withVirtualMachineSize(
                 ContainerServiceVMSizeTypes.fromString(

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/KubernetesClientProviderImpl.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/KubernetesClientProviderImpl.java
@@ -40,7 +40,7 @@ public class KubernetesClientProviderImpl implements KubernetesClientProvider {
             .manager()
             .serviceClient()
             .getManagedClusters()
-            .listClusterUserCredentials(mrgName, aksClusterName)
+            .listClusterAdminCredentials(mrgName, aksClusterName)
             .kubeconfigs()
             .stream()
             .findFirst()

--- a/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksStepTest.java
+++ b/service/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksStepTest.java
@@ -154,6 +154,9 @@ class CreateAksStepTest extends BaseStepTest {
     when(mockParametersResolver.getValue(
             CromwellBaseResourcesFactory.ParametersNames.AKS_AUTOSCALING_ENABLED.name()))
         .thenReturn("false");
+    when(mockParametersResolver.getValue(
+            CromwellBaseResourcesFactory.ParametersNames.AKS_AAD_PROFILE_USER_GROUP_ID.name()))
+        .thenReturn("00000000-0000-0000-0000-000000000000");
   }
 
   private void setupArmManagersForDoStep() {
@@ -166,6 +169,8 @@ class CreateAksStepTest extends BaseStepTest {
     when(mockK8sAPDefinitionStagesWithAttach.attach()).thenReturn(mockK8sDefinition);
     when(mockK8sAPDefinitionStagesWithAttach.withVirtualNetwork(anyString(), anyString()))
         .thenReturn(mockK8sAPDefinitionStagesWithAttach);
+    when(mockK8sDefinitionStageWithCreate.withAzureActiveDirectoryGroup(anyString()))
+        .thenReturn(mockK8sDefinitionStageWithCreate);
     when(mockK8sAPDefinitionStagesWithAttach.withAgentPoolMode(eq(AgentPoolMode.SYSTEM)))
         .thenReturn(mockK8sAPDefinitionStagesWithAttach);
     when(mockK8sAPDefinitionStagesMachineCount.withAgentPoolVirtualMachineCount(anyInt()))


### PR DESCRIPTION
Microsoft security guidelines now require an additional AAD authentication step when using user credentials for AKS. This and related PRs are to switch Terra services to using admin credentials and set a default AAD group when the AKS cluster is created.  