### PR TITLE
Set retention days to 0 to handle api deprecation

### DIFF
--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksLogSettingsStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksLogSettingsStep.java
@@ -22,7 +22,8 @@ public class CreateAksLogSettingsStep extends BaseResourceCreateStep {
   private static final Logger logger = LoggerFactory.getLogger(CreateAksLogSettingsStep.class);
 
   // set the retention days to zero to handle azure API deprecation
-  // see https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/migrate-to-azure-storage-lifecycle-policy
+  // see
+  // https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/migrate-to-azure-storage-lifecycle-policy
   private static final int RETENTION_DAYS = 0;
   private static final Map<String, Integer> AKS_LOGS_TO_CAPTURE =
       Map.ofEntries(

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksLogSettingsStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksLogSettingsStep.java
@@ -21,8 +21,9 @@ import org.slf4j.LoggerFactory;
 public class CreateAksLogSettingsStep extends BaseResourceCreateStep {
   private static final Logger logger = LoggerFactory.getLogger(CreateAksLogSettingsStep.class);
 
-  // 365 is the max value; this is the limitation of Azure
-  private static final int RETENTION_DAYS = 365;
+  // set the retention days to zero to handle azure API deprecation
+  // see https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/migrate-to-azure-storage-lifecycle-policy
+  private static final int RETENTION_DAYS = 0;
   private static final Map<String, Integer> AKS_LOGS_TO_CAPTURE =
       Map.ofEntries(
           entry("kube-apiserver", RETENTION_DAYS),


### PR DESCRIPTION
Setting the log retention settings during AKS cluster creation is causing failures due to an API deprecation from Azure (see this doc). 