### PR TITLE
WOR-1166 Switch to generic resource deletion for this resource type 'virtualNetworkLink'

### DIFF
--- a/service/src/main/java/bio/terra/landingzone/library/landingzones/management/ResourcesDeleteManager.java
+++ b/service/src/main/java/bio/terra/landingzone/library/landingzones/management/ResourcesDeleteManager.java
@@ -1,6 +1,5 @@
 package bio.terra.landingzone.library.landingzones.management;
 
-import bio.terra.landingzone.common.VirtualNetworkLinkResourceHelper;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
 import bio.terra.landingzone.library.landingzones.management.deleterules.LandingZoneRuleDeleteException;
@@ -162,15 +161,11 @@ public class ResourcesDeleteManager {
               });
     }
 
-    if (resourceToDelete.resource().id().contains("virtualNetworkLinks")) {
-      // this is temporary solution since generic deletion is failing for this type of resource
-      VirtualNetworkLinkResourceHelper.delete(armManagers, resourceToDelete.resource().id());
-    } else {
-      armManagers
-          .azureResourceManager()
-          .genericResources()
-          .deleteById(resourceToDelete.resource().id());
-    }
+    armManagers
+        .azureResourceManager()
+        .genericResources()
+        .deleteById(resourceToDelete.resource().id());
+
     logger.info("Resource deleted. id:{}", resourceToDelete.resource().id());
 
     return resourceToDelete.resource();


### PR DESCRIPTION
The previous version of SDK has issue with the deletion of a resource with the following type 'privateDnsZones/virtualNetworkLinks' when using generic deletion API. This issue was resolved in the latest (2.30.0) version.

This PR:
-switch to the latest version (2.30.0)
-revert deletion mechanism to use generic deletion API.