### PR TITLE
[PF-2972] Remove unused dependency

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -20,7 +20,6 @@ dependencies {
     implementation 'bio.terra:billing-profile-manager-client:0.1.29-SNAPSHOT'
     implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
     implementation 'org.postgresql:postgresql:42.6.0'
-    implementation 'javax.servlet:jstl:1.2'
     implementation group: 'com.azure', name: 'azure-core', version: '1.43.0'
     implementation (group: 'com.azure', name: 'azure-identity', version: '1.10.0') {
         // the msal4j transitive dependency is still pulling in an old version of json-smart


### PR DESCRIPTION
`javax.servlet:jstl:1.2` was flagged as having a known security vulnerability in a recent scan, and downstream clients which depend on Landing Zone Service are also impacted (e.g. WSM). This library was included when this service was first split out into its own repo, but does not appear to be used anywhere in the code.