### PR TITLE
WOR-1213 Long Azure MRG name causes landing zone to fail to create

### DIFF
--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksStep.java
@@ -178,27 +178,4 @@ public class CreateAksStep extends BaseResourceCreateStep {
   private String getNodeResourceGroup(String resourceName, String region) {
     return "nrg_%s_%s".formatted(resourceName, region);
   }
-
-  /**
-   * Define name of the AKS node resource group using existing pattern
-   * MC_resourceGroupName_resourceName_AzureRegion. In case name exceeds 80 characters it will be
-   * adjusted by trimming value of 'resourceGroupName'.
-   *
-   * @return name of the node resource group
-   */
-  private String getNodeResourceGroup2(
-      String resourceGroupName, String resourceName, String region) {
-    int nodeResourceGroupMaxLength = 80;
-    String nodeResourceGroupPattern = "MC_%s_%s_%s";
-    var result = nodeResourceGroupPattern.formatted(resourceGroupName, resourceName, region);
-    if (result.length() > nodeResourceGroupMaxLength) {
-      result =
-          result.replace(
-              resourceGroupName,
-              resourceGroupName.substring(
-                  0,
-                  resourceGroupName.length() - (result.length() - nodeResourceGroupMaxLength) - 1));
-    }
-    return result;
-  }
 }


### PR DESCRIPTION
Set up custom name for the node resource group for AKS cluster to limit it's length and prevent Azure error during AKS creation.
Earlier name of the node resource group was generated automatically somewhere down the SDK and was built from 4 different parts divided by underscore: 1) prefix 2) name of the MRG 3) AKS resource name 4) region. Name of the MRG (managed resource group) can vary and as a result the node resource group can exceed the limit of 80 characters. Now we are setting it manually during creation.