### PR TITLE
WOR-1233 Landing Zone creation steps should be idempotent.

### DIFF
--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksStep.java
@@ -187,6 +187,7 @@ public class CreateAksStep extends BaseResourceCreateStep {
         }
       } while (aksNotProvisioned);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new ResourceCreationException(e.getMessage(), e);
     }
     return existingAks;

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksStep.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateAksStep.java
@@ -92,7 +92,7 @@ public class CreateAksStep extends BaseResourceCreateStep {
               .withExistingResourceGroup(getMRGName(context))
               .withDefaultVersion()
               .withSystemAssignedManagedServiceIdentity()
-              .withAgentPoolResourceGroup(getNodeResourceGroup(getMRGRegionName(context)))
+              .withAgentPoolResourceGroup(getNodeResourceGroup(getMRGName(context)))
               .withAzureActiveDirectoryGroup(
                   parametersResolver.getValue(
                       CromwellBaseResourcesFactory.ParametersNames.AKS_AAD_PROFILE_USER_GROUP_ID

--- a/service/src/main/java/bio/terra/landingzone/stairway/flight/exception/ResourceCreationException.java
+++ b/service/src/main/java/bio/terra/landingzone/stairway/flight/exception/ResourceCreationException.java
@@ -1,0 +1,11 @@
+package bio.terra.landingzone.stairway.flight.exception;
+
+public class ResourceCreationException extends RuntimeException {
+  public ResourceCreationException(String message) {
+    super(message);
+  }
+
+  public ResourceCreationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
Creation of AKS is a long running operation. In case Stairway by some reason resumes landing zone flight at the AKS creation step we need to handle conflict (because we send 2nd request) and poll for AKS provisioned status.