### PR TITLE
DDO-3198 Add Metadata Yaml File to to ingest LZ service into DSP backstage

### DIFF
--- a/foundation.yaml
+++ b/foundation.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: terra-landing-zone-service
+  description: |
+    A Landing Zone is a set of cloud resources that serve 
+    as the underlying infrastructure where workspaces or 
+    other Terra applications can be deployed. 
+    The resources in a Landing Zone define and implement constraints, 
+    provide cross-cutting features, or can be shared. 
+    These resources have a different lifecycle than resources in workspaces.
+  tags:
+    - java
+    - dsp
+    - terra
+    - springboot
+    - broadworkspaces
+  annotations:
+    github.com/project-slug: databiosphere/terra-landing-zone-service
+spec:
+  type: library
+  lifecycle: production
+  owner: broadworkspaces
+  system: terra
+  dependsOn:
+    - component:sam
+    - component:terra-billing-profile-manager
+---


### PR DESCRIPTION
This is a functional no-op PR that just adds a metadata file to the LZ service repo that is used to ingest LZ service into [DSP's backstage instance](https://backstage.dsp-devops.broadinstitute.org/catalog?filters%5Bkind%5D=component&filters%5Buser%5D=owned). Backstage is an internal platform tool that can be used for a lot of SDLC processes and improving Dev experience. DevOps is just starting to experiment with this as a means to make getting a new service stood up in the terra environments and through the prod readiness checklist easier.

But we also want all our existing services to be in the system so they can get any benefits.