### PR TITLE
Add a backwards compatible layer for Azure creds

### DIFF
--- a/library/src/main/java/bio/terra/landingzone/common/utils/LandingZoneFlightBeanBag.java
+++ b/library/src/main/java/bio/terra/landingzone/common/utils/LandingZoneFlightBeanBag.java
@@ -1,6 +1,7 @@
 package bio.terra.landingzone.common.utils;
 
 import bio.terra.landingzone.db.LandingZoneDao;
+import bio.terra.landingzone.library.AzureCredentialsProvider;
 import bio.terra.landingzone.library.LandingZoneManagerProvider;
 import bio.terra.landingzone.library.configuration.AzureCustomerUsageConfiguration;
 import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfiguration;
@@ -24,6 +25,7 @@ public class LandingZoneFlightBeanBag {
   private final ObjectMapper objectMapper;
   private final LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration;
   private final AzureCustomerUsageConfiguration azureCustomerUsageConfiguration;
+  private final AzureCredentialsProvider azureCredentialsProvider;
 
   @Lazy
   @Autowired
@@ -36,6 +38,7 @@ public class LandingZoneFlightBeanBag {
       LandingZoneBillingProfileManagerService bpmService,
       LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration,
       AzureCustomerUsageConfiguration azureCustomerUsageConfiguration,
+      AzureCredentialsProvider azureCredentialsProvider,
       ObjectMapper objectMapper) {
     this.landingZoneService = landingZoneService;
     this.landingZoneDao = landingZoneDao;
@@ -45,6 +48,7 @@ public class LandingZoneFlightBeanBag {
     this.bpmService = bpmService;
     this.landingZoneProtectedDataConfiguration = landingZoneProtectedDataConfiguration;
     this.azureCustomerUsageConfiguration = azureCustomerUsageConfiguration;
+    this.azureCredentialsProvider = azureCredentialsProvider;
     this.objectMapper = objectMapper;
   }
 
@@ -86,5 +90,9 @@ public class LandingZoneFlightBeanBag {
 
   public AzureCustomerUsageConfiguration getAzureCustomerUsageConfiguration() {
     return azureCustomerUsageConfiguration;
+  }
+
+  public AzureCredentialsProvider getAzureCredentialsProvider() {
+    return azureCredentialsProvider;
   }
 }

--- a/library/src/main/java/bio/terra/landingzone/library/AzureCredentialsProvider.java
+++ b/library/src/main/java/bio/terra/landingzone/library/AzureCredentialsProvider.java
@@ -1,0 +1,44 @@
+package bio.terra.landingzone.library;
+
+import bio.terra.landingzone.library.configuration.LandingZoneAzureConfiguration;
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.ClientSecretCredentialBuilder;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * This class will attempt to get Azure credentials, starting with our legacy spring configuration
+ * and falling back to the `DefaultAzureCredentialsBuilder`.
+ *
+ * <p>It is intended as a backwards compatibility layer for WSM as it does not wire up the
+ * credentials needed by DefaultAzureCredentialsBuilder in CI scenarios where landing zones are
+ * involved.
+ *
+ * <p>This class should be removed upon full de-amalgamation from WSM.
+ */
+@Component
+public class AzureCredentialsProvider {
+
+  private final LandingZoneAzureConfiguration azureConfiguration;
+
+  @Autowired
+  public AzureCredentialsProvider(LandingZoneAzureConfiguration azureConfiguration) {
+    this.azureConfiguration = azureConfiguration;
+  }
+
+  public TokenCredential getTokenCredential() {
+    if (Objects.nonNull(azureConfiguration.getManagedAppTenantId())
+        && Objects.nonNull(azureConfiguration.getManagedAppClientSecret())
+        && Objects.nonNull(azureConfiguration.getManagedAppClientId())) {
+      return new ClientSecretCredentialBuilder()
+          .clientId(azureConfiguration.getManagedAppClientId())
+          .clientSecret(azureConfiguration.getManagedAppClientSecret())
+          .tenantId(azureConfiguration.getManagedAppTenantId())
+          .build();
+    }
+
+    return new DefaultAzureCredentialBuilder().build();
+  }
+}

--- a/library/src/main/java/bio/terra/landingzone/library/LandingZoneManagerProvider.java
+++ b/library/src/main/java/bio/terra/landingzone/library/LandingZoneManagerProvider.java
@@ -6,7 +6,6 @@ import bio.terra.landingzone.model.LandingZoneTarget;
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.management.AzureEnvironment;
 import com.azure.core.management.profile.AzureProfile;
-import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.azure.resourcemanager.AzureResourceManager;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,11 +14,14 @@ import org.springframework.stereotype.Component;
 @Component
 public class LandingZoneManagerProvider {
   private AzureCustomerUsageConfiguration azureCustomerUsageConfiguration;
+  private final AzureCredentialsProvider azureCredentialsProvider;
 
   @Autowired
   public LandingZoneManagerProvider(
-      AzureCustomerUsageConfiguration azureCustomerUsageConfiguration) {
+      AzureCustomerUsageConfiguration azureCustomerUsageConfiguration,
+      AzureCredentialsProvider azureCredentialsProvider) {
     this.azureCustomerUsageConfiguration = azureCustomerUsageConfiguration;
+    this.azureCredentialsProvider = azureCredentialsProvider;
   }
 
   public LandingZoneManager createLandingZoneManager(LandingZoneTarget landingZoneTarget) {
@@ -47,6 +49,6 @@ public class LandingZoneManagerProvider {
   }
 
   public TokenCredential buildTokenCredential() {
-    return new DefaultAzureCredentialBuilder().build();
+    return azureCredentialsProvider.getTokenCredential();
   }
 }

--- a/library/src/main/java/bio/terra/landingzone/library/configuration/LandingZoneAzureConfiguration.java
+++ b/library/src/main/java/bio/terra/landingzone/library/configuration/LandingZoneAzureConfiguration.java
@@ -1,0 +1,37 @@
+package bio.terra.landingzone.library.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "workspace.azure")
+public class LandingZoneAzureConfiguration {
+  // Managed app authentication
+  private String managedAppClientId;
+  private String managedAppClientSecret;
+  private String managedAppTenantId;
+
+  public String getManagedAppClientId() {
+    return managedAppClientId;
+  }
+
+  public void setManagedAppClientId(String managedAppClientId) {
+    this.managedAppClientId = managedAppClientId;
+  }
+
+  public String getManagedAppClientSecret() {
+    return managedAppClientSecret;
+  }
+
+  public void setManagedAppClientSecret(String managedAppClientSecret) {
+    this.managedAppClientSecret = managedAppClientSecret;
+  }
+
+  public String getManagedAppTenantId() {
+    return managedAppTenantId;
+  }
+
+  public void setManagedAppTenantId(String managedAppTenantId) {
+    this.managedAppTenantId = managedAppTenantId;
+  }
+}

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlight.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlight.java
@@ -2,6 +2,7 @@ package bio.terra.landingzone.stairway.flight.create;
 
 import bio.terra.landingzone.common.utils.LandingZoneFlightBeanBag;
 import bio.terra.landingzone.common.utils.RetryRules;
+import bio.terra.landingzone.library.AzureCredentialsProvider;
 import bio.terra.landingzone.library.configuration.AzureCustomerUsageConfiguration;
 import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfiguration;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
@@ -22,7 +23,6 @@ import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
 import com.azure.core.management.AzureEnvironment;
 import com.azure.core.management.profile.AzureProfile;
-import com.azure.identity.DefaultAzureCredentialBuilder;
 import java.util.UUID;
 
 public class CreateLandingZoneResourcesFlight extends Flight {
@@ -33,6 +33,7 @@ public class CreateLandingZoneResourcesFlight extends Flight {
   private final ResourceNameProvider resourceNameProvider;
   private final ParametersResolver parametersResolver;
   private final LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration;
+  private final AzureCredentialsProvider azureCredentialsProvider;
 
   /**
    * All subclasses must provide a constructor with this signature.
@@ -45,6 +46,8 @@ public class CreateLandingZoneResourcesFlight extends Flight {
 
     final LandingZoneFlightBeanBag flightBeanBag =
         LandingZoneFlightBeanBag.getFromObject(applicationContext);
+
+    azureCredentialsProvider = flightBeanBag.getAzureCredentialsProvider();
 
     landingZoneRequest =
         inputParameters.get(
@@ -93,7 +96,7 @@ public class CreateLandingZoneResourcesFlight extends Flight {
             landingZoneTarget.azureTenantId(),
             landingZoneTarget.azureSubscriptionId(),
             AzureEnvironment.AZURE);
-    var tokenCredentials = new DefaultAzureCredentialBuilder().build();
+    var tokenCredentials = azureCredentialsProvider.getTokenCredential();
     return LandingZoneManager.createArmManagers(
         tokenCredentials, azureProfile, azureCustomerUsageConfiguration.getUsageAttribute());
   }


### PR DESCRIPTION
Workspace Manager integration tests fail with the current LZ lib as WSM doesn't wire up the needed Azure credentials/login in it's CI pipeline. I've introduced a backwards compatibility layer to keep things functional there and unblock things. We will want to remove this shim once LZS is deamalgamated.