### PR TITLE
WOR-1339 Landing zone intermittently fails to create

### DIFF
--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/BaseResourceCreateStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/BaseResourceCreateStep.java
@@ -32,7 +32,7 @@ public abstract class BaseResourceCreateStep implements Step {
   private static final Logger logger = LoggerFactory.getLogger(BaseResourceCreateStep.class);
 
   protected static final String FAILED_TO_CREATE_RESOURCE =
-      "Failed to create landing zone {} resource. landingZoneId={}: {}";
+      "Failed to create landing zone %s resource. landingZoneId=%s: %s";
   protected static final String RESOURCE_ALREADY_EXISTS =
       "{} resource in managed resource group {} already exists.";
   protected static final String RESOURCE_CREATED =
@@ -172,7 +172,8 @@ public abstract class BaseResourceCreateStep implements Step {
       logger.info(RESOURCE_ALREADY_EXISTS, getResourceType(), managedResourceGroup);
       return StepResult.getStepResultSuccess();
     }
-    logger.error(FAILED_TO_CREATE_RESOURCE, getResourceType(), landingZoneId, e.toString());
+    logger.error(
+        FAILED_TO_CREATE_RESOURCE.formatted(getResourceType(), landingZoneId, e.toString()), e);
     MetricUtils.incrementLandingZoneCreationFailure(landingZoneType);
     return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
   }

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/BaseResourceCreateStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/BaseResourceCreateStep.java
@@ -10,6 +10,7 @@ import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
 import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
 import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
+import bio.terra.landingzone.stairway.flight.exception.utils.ManagementExceptionUtils;
 import bio.terra.landingzone.stairway.flight.utils.FlightUtils;
 import bio.terra.profile.model.ProfileModel;
 import bio.terra.stairway.FlightContext;
@@ -32,7 +33,7 @@ public abstract class BaseResourceCreateStep implements Step {
   private static final Logger logger = LoggerFactory.getLogger(BaseResourceCreateStep.class);
 
   protected static final String FAILED_TO_CREATE_RESOURCE =
-      "Failed to create landing zone %s resource. landingZoneId=%s. Error: %s";
+      "Failed to create landing zone {} resource. landingZoneId={}. Error: {}";
   protected static final String RESOURCE_ALREADY_EXISTS =
       "{} resource in managed resource group {} already exists.";
   protected static final String RESOURCE_CREATED =
@@ -173,7 +174,10 @@ public abstract class BaseResourceCreateStep implements Step {
       return StepResult.getStepResultSuccess();
     }
     logger.error(
-        FAILED_TO_CREATE_RESOURCE.formatted(getResourceType(), landingZoneId, e.toString()), e);
+        FAILED_TO_CREATE_RESOURCE,
+        getResourceType(),
+        landingZoneId,
+        ManagementExceptionUtils.buildErrorInfo(e));
     MetricUtils.incrementLandingZoneCreationFailure(landingZoneType);
     return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
   }

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/BaseResourceCreateStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/BaseResourceCreateStep.java
@@ -32,7 +32,7 @@ public abstract class BaseResourceCreateStep implements Step {
   private static final Logger logger = LoggerFactory.getLogger(BaseResourceCreateStep.class);
 
   protected static final String FAILED_TO_CREATE_RESOURCE =
-      "Failed to create landing zone %s resource. landingZoneId=%s: %s";
+      "Failed to create landing zone %s resource. landingZoneId=%s. Error: %s";
   protected static final String RESOURCE_ALREADY_EXISTS =
       "{} resource in managed resource group {} already exists.";
   protected static final String RESOURCE_CREATED =

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreatePostgresqlDbStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreatePostgresqlDbStep.java
@@ -221,6 +221,7 @@ public class CreatePostgresqlDbStep extends BaseResourceCreateStep {
    2) Enabling pgbouncer 3) Creating admin user. This particular method works as a global handler for
    the whole step. But current implementation handles specific Postgres db provisioning issue.
   */
+  @Override
   protected Optional<StepResult> maybeHandleManagementException(ManagementException e) {
     final String resourceOperationFailure = "ResourceOperationFailure";
     final String internalServerError = "InternalServerError";

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreatePostgresqlDbStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreatePostgresqlDbStep.java
@@ -11,6 +11,8 @@ import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
 import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
 import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
 import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.postgresqlflexibleserver.models.ActiveDirectoryAuthEnum;
 import com.azure.resourcemanager.postgresqlflexibleserver.models.AuthConfig;
@@ -32,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -210,6 +213,25 @@ public class CreatePostgresqlDbStep extends BaseResourceCreateStep {
         }
       }
     }
+  }
+
+  /*
+   Current step is responsible for multiple postgres operations such as 1) DB server provisioning
+   2) Enabling pgbouncer 3) Creating admin user. This particular method works as a global handler for
+   the whole step. But current implementation handles specific Postgres db provisioning issue.
+  */
+  protected Optional<StepResult> maybeHandleManagementException(ManagementException e) {
+    final String resourceOperationFailure = "ResourceOperationFailure";
+    final String internalServerError = "InternalServerError";
+    if (e.getValue() != null
+        && StringUtils.equalsIgnoreCase(e.getValue().getCode(), resourceOperationFailure)
+        && e.getValue().getDetails() != null
+        && e.getValue().getDetails().stream()
+            .anyMatch(d -> StringUtils.equalsIgnoreCase(d.getCode(), internalServerError))) {
+      logger.warn("Postgres provisioning failure. Error: {}.", e.getMessage());
+      return Optional.of(new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY));
+    }
+    return Optional.empty();
   }
 
   @Override

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreatePostgresqlDbStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreatePostgresqlDbStep.java
@@ -10,6 +10,7 @@ import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
 import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
 import bio.terra.landingzone.stairway.flight.ResourceNameRequirements;
+import bio.terra.landingzone.stairway.flight.exception.utils.ManagementExceptionUtils;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
@@ -228,7 +229,8 @@ public class CreatePostgresqlDbStep extends BaseResourceCreateStep {
         && e.getValue().getDetails() != null
         && e.getValue().getDetails().stream()
             .anyMatch(d -> StringUtils.equalsIgnoreCase(d.getCode(), internalServerError))) {
-      logger.warn("Postgres provisioning failure. Error: {}.", e.getMessage());
+      logger.warn(
+          "Postgres provisioning failure. Error: {}.", ManagementExceptionUtils.buildErrorInfo(e));
       return Optional.of(new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY));
     }
     return Optional.empty();

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/exception/utils/ManagementExceptionUtils.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/exception/utils/ManagementExceptionUtils.java
@@ -9,16 +9,16 @@ public class ManagementExceptionUtils {
 
   public static String buildErrorInfo(ManagementException e) {
     StringBuilder errorDetails = new StringBuilder();
-    errorDetails.append("ErrorMessage: %s; ".formatted(e.getMessage()));
+    errorDetails.append("ErrorMessage: %s;".formatted(e.getMessage()));
     if (e.getValue() != null) {
       errorDetails.append(
-          "ErrorCode: %s; AdditionalMessage: %s;"
+          " ErrorCode: %s; AdditionalMessage: %s;"
               .formatted(
                   Optional.of(e.getValue().getCode()).orElse("n/a"),
                   Optional.of(e.getValue().getMessage()).orElse("n/a")));
       if (e.getValue().getDetails() != null) {
         errorDetails.append(
-            "Details: %s;"
+            " Details: %s;"
                 .formatted(
                     e.getValue().getDetails().stream()
                         .map(

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/exception/utils/ManagementExceptionUtils.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/exception/utils/ManagementExceptionUtils.java
@@ -1,0 +1,32 @@
+package bio.terra.landingzone.stairway.flight.exception.utils;
+
+import com.azure.core.management.exception.ManagementException;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class ManagementExceptionUtils {
+  private ManagementExceptionUtils() {}
+
+  public static String buildErrorInfo(ManagementException e) {
+    StringBuilder errorDetails = new StringBuilder();
+    errorDetails.append("ErrorMessage: %s; ".formatted(e.getMessage()));
+    if (e.getValue() != null) {
+      errorDetails.append(
+          "ErrorCode: %s; AdditionalMessage: %s;"
+              .formatted(
+                  Optional.of(e.getValue().getCode()).orElse("n/a"),
+                  Optional.of(e.getValue().getMessage()).orElse("n/a")));
+      if (e.getValue().getDetails() != null) {
+        errorDetails.append(
+            "Details: %s;"
+                .formatted(
+                    e.getValue().getDetails().stream()
+                        .map(
+                            me ->
+                                "[code: %s, message: %s]".formatted(me.getCode(), me.getMessage()))
+                        .collect(Collectors.joining(","))));
+      }
+    }
+    return errorDetails.toString();
+  }
+}

--- a/library/src/test/java/bio/terra/landingzone/library/landingzones/TestArmResourcesFactory.java
+++ b/library/src/test/java/bio/terra/landingzone/library/landingzones/TestArmResourcesFactory.java
@@ -80,10 +80,12 @@ public class TestArmResourcesFactory {
 
   public static ResourceGroup createTestResourceGroup(AzureResourceManager azureResourceManager) {
     String resourceGroupId = UUID.randomUUID().toString().replace("-", "");
+    // temporarily switch to US_EAST since we have Postgres provisioning issue potentially related
+    // to quota. Details in WOR-1362.
     return azureResourceManager
         .resourceGroups()
         .define("rg" + resourceGroupId)
-        .withRegion(Region.US_SOUTH_CENTRAL)
+        .withRegion(Region.US_EAST)
         .withTag("PURPOSE", "LANDING_ZONE_SERVICE_INTEGRATION_TESTING")
         .create();
   }

--- a/library/src/test/resources/application-test.yml
+++ b/library/src/test/resources/application-test.yml
@@ -53,6 +53,7 @@ landingzone:
     longTermStorageAccountIds:
       #extend configuration in case mrg is in different region; resource id should be fully qualified
       southcentralus: /subscriptions/df547342-9cfd-44ef-a6dd-df0ede32f1e3/resourceGroups/landing-zone-testing/providers/Microsoft.Storage/storageAccounts/ltssthcentralus
+      eastus: /subscriptions/df547342-9cfd-44ef-a6dd-df0ede32f1e3/resourceGroups/landing-zone-testing/providers/Microsoft.Storage/storageAccounts/ltseastus
     sentinelScheduledAlertRuleTemplateIds:
       - 0b9ae89d-8cad-461c-808f-0494f70ad5c4
     sentinelMlRuleTemplateIds:


### PR DESCRIPTION
This PR:
- Handles "Long running operation Failed or Cancelled" issue during Postgres provisioning. As a result, corresponding step could be retried. Fix is based on the following shape of the error:
  `{\"status\":\"Failed\",\"error\":{\"code\":\"ResourceOperationFailure\",\"message\":\"The resource operation completed with terminal provisioning state 'Failed'.\",\"details\":[{\"code\":\"InternalServerError\",\"message\":\"An unexpected error occured while processing the request. Tracking ID: '8a04238e-7145-42d6-a71e-8a82d6f9f819'\"}]}}
  `
- Switch to eastus region for integration test since we have issues in southcentral region related to Postgres provisioning. But this issue is different from what was mentioned above.
- Extends logging of exception information.