### PR TITLE
WOR-1433 [LZS] Remove usage of deprecated ExpandableStringEnum class.

### DIFF
--- a/library/src/main/java/bio/terra/landingzone/library/landingzones/definition/DefinitionVersion.java
+++ b/library/src/main/java/bio/terra/landingzone/library/landingzones/definition/DefinitionVersion.java
@@ -1,22 +1,25 @@
 package bio.terra.landingzone.library.landingzones.definition;
 
-import com.azure.core.util.ExpandableStringEnum;
-
 /** Enum representing the list of possible versions for a given definition. */
-public final class DefinitionVersion extends ExpandableStringEnum<DefinitionVersion> {
-  public static final DefinitionVersion V1 = fromString("v1");
-  public static final DefinitionVersion V2 = fromString("v2");
-  public static final DefinitionVersion V3 = fromString("v3");
-  public static final DefinitionVersion V4 = fromString("v4");
-  public static final DefinitionVersion V5 = fromString("v5");
+public enum DefinitionVersion {
+  V1("v1"),
+  V2("v2"),
+  V3("v3"),
+  V4("v4"),
+  V5("v5");
 
-  /**
-   * Creates or finds a {@link DefinitionVersion} from its string representation.
-   *
-   * @param version a version to look for
-   * @return the corresponding {@link DefinitionVersion}
-   */
-  public static DefinitionVersion fromString(String version) {
-    return fromString(version, DefinitionVersion.class);
+  private String value;
+
+  DefinitionVersion(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return value;
   }
 }

--- a/library/src/main/java/bio/terra/landingzone/library/landingzones/deployment/LandingZoneTagKeys.java
+++ b/library/src/main/java/bio/terra/landingzone/library/landingzones/deployment/LandingZoneTagKeys.java
@@ -1,32 +1,25 @@
 package bio.terra.landingzone.library.landingzones.deployment;
 
-import com.azure.core.util.ExpandableStringEnum;
-import java.util.Collection;
-
 /** Enum of tag keys for resources in the landing zone. */
-public final class LandingZoneTagKeys extends ExpandableStringEnum<LandingZoneTagKeys> {
-  public static final LandingZoneTagKeys LANDING_ZONE_ID = fromString("WLZ-ID");
-  public static final LandingZoneTagKeys LANDING_ZONE_PURPOSE = fromString("WLZ-PURPOSE");
-  public static final LandingZoneTagKeys PGBOUNCER_ENABLED = fromString("pgbouncer-enabled");
-  public static final LandingZoneTagKeys AKS_COST_SAVING_SPOT_NODES_ENABLED =
-      fromString("aks-cost-spot-nodes-enabled");
-  public static final LandingZoneTagKeys AKS_COST_SAVING_VPA_ENABLED =
-      fromString("aks-cost-vpa-enabled");
+public enum LandingZoneTagKeys {
+  LANDING_ZONE_ID("WLZ-ID"),
+  LANDING_ZONE_PURPOSE("WLZ-PURPOSE"),
+  PGBOUNCER_ENABLED("pgbouncer-enabled"),
+  AKS_COST_SAVING_SPOT_NODES_ENABLED("aks-cost-spot-nodes-enabled"),
+  AKS_COST_SAVING_VPA_ENABLED("aks-cost-vpa-enabled");
 
-  /**
-   * Creates or finds a {@link LandingZoneTagKeys} from its string representation.
-   *
-   * @param name a name to look for
-   * @return the corresponding {@link LandingZoneTagKeys}
-   */
-  public static LandingZoneTagKeys fromString(String name) {
-    return fromString(name, LandingZoneTagKeys.class);
+  private String value;
+
+  LandingZoneTagKeys(String value) {
+    this.value = value;
   }
 
-  /**
-   * @return known LandingZoneTagKeys values.
-   */
-  public static Collection<LandingZoneTagKeys> values() {
-    return values(LandingZoneTagKeys.class);
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return value;
   }
 }

--- a/library/src/main/java/bio/terra/landingzone/library/landingzones/deployment/ResourcePurpose.java
+++ b/library/src/main/java/bio/terra/landingzone/library/landingzones/deployment/ResourcePurpose.java
@@ -1,27 +1,23 @@
 package bio.terra.landingzone.library.landingzones.deployment;
 
-import com.azure.core.util.ExpandableStringEnum;
-import java.util.Collection;
-
 /** Enum that indicates the purpose of the resource in the landing zone. */
-public final class ResourcePurpose extends ExpandableStringEnum<ResourcePurpose>
-    implements LandingZonePurpose {
+public enum ResourcePurpose implements LandingZonePurpose {
+  SHARED_RESOURCE("SHARED_RESOURCE"),
+  POSTGRES_ADMIN("POSTGRES_ADMIN"),
+  WLZ_RESOURCE("WLZ_RESOURCE");
 
-  public static final ResourcePurpose SHARED_RESOURCE = fromString("SHARED_RESOURCE");
-  public static final ResourcePurpose POSTGRES_ADMIN = fromString("POSTGRES_ADMIN");
-  public static final ResourcePurpose WLZ_RESOURCE = fromString("WLZ_RESOURCE");
+  private String value;
 
-  /**
-   * Creates or finds a {@link ResourcePurpose} from its string representation.
-   *
-   * @param name a name to look for
-   * @return the corresponding {@link ResourcePurpose}
-   */
-  public static ResourcePurpose fromString(String name) {
-    return fromString(name, ResourcePurpose.class);
+  ResourcePurpose(String value) {
+    this.value = value;
   }
 
-  public static Collection<ResourcePurpose> values() {
-    return values(ResourcePurpose.class);
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return value;
   }
 }

--- a/library/src/main/java/bio/terra/landingzone/library/landingzones/deployment/SubnetResourcePurpose.java
+++ b/library/src/main/java/bio/terra/landingzone/library/landingzones/deployment/SubnetResourcePurpose.java
@@ -1,32 +1,25 @@
 package bio.terra.landingzone.library.landingzones.deployment;
 
-import com.azure.core.util.ExpandableStringEnum;
-import java.util.Collection;
-
 /** Enum of the subnet purposes */
-public final class SubnetResourcePurpose extends ExpandableStringEnum<SubnetResourcePurpose>
-    implements LandingZonePurpose {
-  public static final SubnetResourcePurpose WORKSPACE_COMPUTE_SUBNET =
-      fromString("WORKSPACE_COMPUTE_SUBNET");
-  public static final SubnetResourcePurpose WORKSPACE_STORAGE_SUBNET =
-      fromString("WORKSPACE_STORAGE_SUBNET");
-  public static final SubnetResourcePurpose AKS_NODE_POOL_SUBNET =
-      fromString("AKS_NODE_POOL_SUBNET");
-  public static final SubnetResourcePurpose POSTGRESQL_SUBNET = fromString("POSTGRESQL_SUBNET");
-  public static final SubnetResourcePurpose WORKSPACE_BATCH_SUBNET =
-      fromString("WORKSPACE_BATCH_SUBNET");
+public enum SubnetResourcePurpose implements LandingZonePurpose {
+  WORKSPACE_COMPUTE_SUBNET("WORKSPACE_COMPUTE_SUBNET"),
+  WORKSPACE_STORAGE_SUBNET("WORKSPACE_STORAGE_SUBNET"),
+  AKS_NODE_POOL_SUBNET("AKS_NODE_POOL_SUBNET"),
+  POSTGRESQL_SUBNET("POSTGRESQL_SUBNET"),
+  WORKSPACE_BATCH_SUBNET("WORKSPACE_BATCH_SUBNET");
 
-  /**
-   * Creates or finds a {@link SubnetResourcePurpose} from its string representation.
-   *
-   * @param name a name to look for
-   * @return the corresponding {@link SubnetResourcePurpose}
-   */
-  public static SubnetResourcePurpose fromString(String name) {
-    return fromString(name, SubnetResourcePurpose.class);
+  private String value;
+
+  SubnetResourcePurpose(String value) {
+    this.value = value;
   }
 
-  public static Collection<SubnetResourcePurpose> values() {
-    return values(SubnetResourcePurpose.class);
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return value;
   }
 }

--- a/library/src/main/java/bio/terra/landingzone/library/landingzones/management/ResourcesReaderImpl.java
+++ b/library/src/main/java/bio/terra/landingzone/library/landingzones/management/ResourcesReaderImpl.java
@@ -12,7 +12,7 @@ import com.azure.resourcemanager.network.models.Network;
 import com.azure.resourcemanager.resources.models.GenericResource;
 import com.azure.resourcemanager.resources.models.ResourceGroup;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -184,7 +184,8 @@ public class ResourcesReaderImpl implements ResourcesReader {
   }
 
   private DeployedVNet toDeployedVNet(Network network) {
-    HashMap<SubnetResourcePurpose, DeployedSubnet> subnetHashMap = new HashMap<>();
+    EnumMap<SubnetResourcePurpose, DeployedSubnet> subnetHashMap =
+        new EnumMap<>(SubnetResourcePurpose.class);
 
     Arrays.stream(SubnetResourcePurpose.values())
         .toList()

--- a/library/src/main/java/bio/terra/landingzone/library/landingzones/management/ResourcesReaderImpl.java
+++ b/library/src/main/java/bio/terra/landingzone/library/landingzones/management/ResourcesReaderImpl.java
@@ -11,6 +11,7 @@ import com.azure.resourcemanager.AzureResourceManager;
 import com.azure.resourcemanager.network.models.Network;
 import com.azure.resourcemanager.resources.models.GenericResource;
 import com.azure.resourcemanager.resources.models.ResourceGroup;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -185,7 +186,8 @@ public class ResourcesReaderImpl implements ResourcesReader {
   private DeployedVNet toDeployedVNet(Network network) {
     HashMap<SubnetResourcePurpose, DeployedSubnet> subnetHashMap = new HashMap<>();
 
-    SubnetResourcePurpose.values()
+    Arrays.stream(SubnetResourcePurpose.values())
+        .toList()
         .forEach(
             p -> {
               var subnetName = network.tags().get(p.toString());

--- a/library/src/main/java/bio/terra/landingzone/service/landingzone/azure/LandingZoneService.java
+++ b/library/src/main/java/bio/terra/landingzone/service/landingzone/azure/LandingZoneService.java
@@ -534,14 +534,15 @@ public class LandingZoneService {
         .collect(
             Collectors.groupingBy(
                 r ->
-                    ResourcePurpose.fromString(
+                    ResourcePurpose.valueOf(
                         r.tags().get(LandingZoneTagKeys.LANDING_ZONE_PURPOSE.toString()))));
   }
 
   private Map<LandingZonePurpose, List<LandingZoneResource>> listSubnetResourcesWithPurposes(
       String landingZoneId, LandingZoneManager landingZoneManager) {
     Map<LandingZonePurpose, List<LandingZoneResource>> subnetPurposeMap = new HashMap<>();
-    SubnetResourcePurpose.values()
+    Arrays.stream(SubnetResourcePurpose.values())
+        .toList()
         .forEach(
             p ->
                 subnetPurposeMap.put(


### PR DESCRIPTION
This PR:
- Replaces usage of ExpandableStringEnum(deprecated) with Java's enum.