### PR TITLE
[NO TICKET] Group dependabot updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     open-pull-requests-limit: 10
+    groups:
+      minor-patch-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     schedule:
       interval: "weekly"
       time: "06:00"


### PR DESCRIPTION
To cut down on the number of individual PRs, group minor release updates (which should have no breaking changes) together.