### PR TITLE
WOR-1436: persist region

### DIFF
--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateAzureLandingZoneDbRecordStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateAzureLandingZoneDbRecordStep.java
@@ -4,7 +4,9 @@ import bio.terra.landingzone.db.LandingZoneDao;
 import bio.terra.landingzone.db.model.LandingZoneRecord;
 import bio.terra.landingzone.model.LandingZoneTarget;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneRequest;
+import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.create.resource.step.GetManagedResourceGroupInfo;
 import bio.terra.landingzone.stairway.flight.utils.FlightUtils;
 import bio.terra.profile.model.ProfileModel;
 import bio.terra.stairway.FlightContext;
@@ -43,6 +45,14 @@ public class CreateAzureLandingZoneDbRecordStep implements Step {
     var billingProfile = inputMap.get(LandingZoneFlightMapKeys.BILLING_PROFILE, ProfileModel.class);
     var landingZoneTarget = LandingZoneTarget.fromBillingProfile(billingProfile);
 
+    // Read Working Map parameters
+    var mrg =
+        FlightUtils.getRequired(
+            context.getWorkingMap(),
+            GetManagedResourceGroupInfo.TARGET_MRG_KEY,
+            TargetManagedResourceGroup.class);
+
+
     // Persist the landing zone record
     landingZoneDao.createLandingZone(
         LandingZoneRecord.builder()
@@ -59,6 +69,7 @@ public class CreateAzureLandingZoneDbRecordStep implements Step {
             .resourceGroupId(landingZoneTarget.azureResourceGroupId())
             .tenantId(landingZoneTarget.azureTenantId())
             .subscriptionId(landingZoneTarget.azureSubscriptionId())
+            .region(mrg.region())
             .billingProfileId(requestedExternalLandingZoneResource.billingProfileId())
             .createdDate(OffsetDateTime.ofInstant(Instant.now(), ZoneOffset.UTC))
             .build());

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateAzureLandingZoneDbRecordStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateAzureLandingZoneDbRecordStep.java
@@ -1,6 +1,6 @@
 package bio.terra.landingzone.stairway.flight.create;
 
-import bio.terra.landingzone.db.LandingZoneDao;
+import bio.terra.landingzone.common.utils.LandingZoneFlightBeanBag;
 import bio.terra.landingzone.db.model.LandingZoneRecord;
 import bio.terra.landingzone.model.LandingZoneTarget;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneRequest;
@@ -24,14 +24,12 @@ import org.slf4j.LoggerFactory;
 public class CreateAzureLandingZoneDbRecordStep implements Step {
   private static final Logger logger =
       LoggerFactory.getLogger(CreateAzureLandingZoneDbRecordStep.class);
-  private final LandingZoneDao landingZoneDao;
-
-  public CreateAzureLandingZoneDbRecordStep(LandingZoneDao landingZoneDao) {
-    this.landingZoneDao = landingZoneDao;
-  }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    var beanBag = LandingZoneFlightBeanBag.getFromObject(context.getApplicationContext());
+    var landingZoneDao = beanBag.getLandingZoneDao();
+
     // Read input parameters
     final FlightMap inputMap = context.getInputParameters();
     FlightUtils.validateRequiredEntries(
@@ -51,7 +49,6 @@ public class CreateAzureLandingZoneDbRecordStep implements Step {
             context.getWorkingMap(),
             GetManagedResourceGroupInfo.TARGET_MRG_KEY,
             TargetManagedResourceGroup.class);
-
 
     // Persist the landing zone record
     landingZoneDao.createLandingZone(
@@ -78,6 +75,9 @@ public class CreateAzureLandingZoneDbRecordStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext context) throws InterruptedException {
+    var beanBag = LandingZoneFlightBeanBag.getFromObject(context.getApplicationContext());
+    var landingZoneDao = beanBag.getLandingZoneDao();
+
     final FlightMap inputMap = context.getInputParameters();
     FlightUtils.validateRequiredEntries(inputMap, LandingZoneFlightMapKeys.LANDING_ZONE_ID);
     var landingZoneId = inputMap.get(LandingZoneFlightMapKeys.LANDING_ZONE_ID, UUID.class);

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneFlight.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneFlight.java
@@ -75,9 +75,7 @@ public class CreateLandingZoneFlight extends Flight {
       addStep(new AggregateLandingZoneResourcesStep(), RetryRules.shortExponential());
     }
 
-    addStep(
-        new CreateAzureLandingZoneDbRecordStep(flightBeanBag.getLandingZoneDao()),
-        RetryRules.shortDatabase());
+    addStep(new CreateAzureLandingZoneDbRecordStep(), RetryRules.shortDatabase());
   }
 
   private UUID getLandingZoneId(FlightMap inputParameters, LandingZoneRequest landingZoneRequest) {

--- a/library/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateAzureLandingZoneDbRecordStepTest.java
+++ b/library/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateAzureLandingZoneDbRecordStepTest.java
@@ -1,0 +1,119 @@
+package bio.terra.landingzone.stairway.flight.create;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.landingzone.common.utils.LandingZoneFlightBeanBag;
+import bio.terra.landingzone.db.LandingZoneDao;
+import bio.terra.landingzone.db.model.LandingZoneRecord;
+import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneRequest;
+import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
+import bio.terra.landingzone.stairway.flight.FlightTestUtils;
+import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.create.resource.step.GetManagedResourceGroupInfo;
+import bio.terra.profile.model.ProfileModel;
+import bio.terra.stairway.FlightContext;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("unit")
+public class CreateAzureLandingZoneDbRecordStepTest {
+
+  @Mock private LandingZoneDao landingZoneDao;
+  @Mock private LandingZoneFlightBeanBag landingZoneFlightBeanBag;
+  @Mock private FlightContext context;
+
+  @BeforeEach
+  public void setup() {
+    when(landingZoneFlightBeanBag.getLandingZoneDao()).thenReturn(landingZoneDao);
+    when(context.getApplicationContext()).thenReturn(landingZoneFlightBeanBag);
+  }
+
+  @Test
+  public void doStepPersistsDBRecordWithCorrectFields() throws Exception {
+    var expectedLandingZone =
+        LandingZoneRecord.builder()
+            .landingZoneId(UUID.randomUUID())
+            .description("Definition:%s Version:%s")
+            .displayName("test")
+            .definition("test")
+            .properties(Map.of())
+            .resourceGroupId(UUID.randomUUID().toString())
+            .tenantId(UUID.randomUUID().toString())
+            .subscriptionId(UUID.randomUUID().toString())
+            .region("test-region")
+            .billingProfileId(UUID.randomUUID())
+            .build();
+
+    var landingZoneRequest =
+        LandingZoneRequest.builder()
+            .definition(expectedLandingZone.definition())
+            .version(expectedLandingZone.version())
+            .billingProfileId(expectedLandingZone.billingProfileId())
+            .parameters(expectedLandingZone.properties())
+            .build();
+    var billingProfile =
+        new ProfileModel()
+            .id(expectedLandingZone.billingProfileId())
+            .managedResourceGroupId(expectedLandingZone.resourceGroupId())
+            .tenantId(UUID.fromString(expectedLandingZone.tenantId()))
+            .subscriptionId(UUID.fromString(expectedLandingZone.subscriptionId()));
+    var inputMap =
+        FlightTestUtils.prepareFlightInputParameters(
+            Map.of(
+                LandingZoneFlightMapKeys.LANDING_ZONE_CREATE_PARAMS, landingZoneRequest,
+                LandingZoneFlightMapKeys.LANDING_ZONE_ID, expectedLandingZone.landingZoneId(),
+                LandingZoneFlightMapKeys.BILLING_PROFILE, billingProfile));
+    var workingMap =
+        FlightTestUtils.prepareFlightWorkingParameters(
+            Map.of(
+                GetManagedResourceGroupInfo.TARGET_MRG_KEY,
+                new TargetManagedResourceGroup(
+                    expectedLandingZone.resourceGroupId(), expectedLandingZone.region())));
+    when(context.getInputParameters()).thenReturn(inputMap);
+    when(context.getWorkingMap()).thenReturn(workingMap);
+
+    when(landingZoneDao.createLandingZone(any()))
+        .thenAnswer(
+            invocation -> {
+              var landingZone = invocation.getArgument(0, LandingZoneRecord.class);
+              assertThat(landingZone.displayName(), equalTo(expectedLandingZone.displayName()));
+              assertThat(landingZone.properties(), equalTo(expectedLandingZone.properties()));
+              assertThat(
+                  landingZone.resourceGroupId(), equalTo(expectedLandingZone.resourceGroupId()));
+              assertThat(landingZone.tenantId(), equalTo(expectedLandingZone.tenantId()));
+              assertThat(
+                  landingZone.subscriptionId(), equalTo(expectedLandingZone.subscriptionId()));
+              assertThat(
+                  landingZone.billingProfileId(), equalTo(expectedLandingZone.billingProfileId()));
+              assertThat(landingZone.region(), equalTo(expectedLandingZone.region()));
+              return expectedLandingZone.landingZoneId();
+            });
+    new CreateAzureLandingZoneDbRecordStep().doStep(context);
+    verify(landingZoneDao).createLandingZone(any());
+  }
+
+  @Test
+  public void undoStepDeletesLandingZoneDBRecord() throws Exception {
+    var landingZoneId = UUID.randomUUID();
+    var inputMap =
+        FlightTestUtils.prepareFlightInputParameters(
+            Map.of(LandingZoneFlightMapKeys.LANDING_ZONE_ID, landingZoneId));
+    when(context.getInputParameters()).thenReturn(inputMap);
+    when(landingZoneDao.deleteLandingZone(landingZoneId)).thenReturn(true);
+    new CreateAzureLandingZoneDbRecordStep().undoStep(context);
+
+    verify(landingZoneDao).deleteLandingZone(landingZoneId);
+  }
+
+}

--- a/library/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateAzureLandingZoneDbRecordStepTest.java
+++ b/library/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateAzureLandingZoneDbRecordStepTest.java
@@ -115,5 +115,4 @@ public class CreateAzureLandingZoneDbRecordStepTest {
 
     verify(landingZoneDao).deleteLandingZone(landingZoneId);
   }
-
 }

--- a/library/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateAzureLandingZoneDbRecordStepTest.java
+++ b/library/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateAzureLandingZoneDbRecordStepTest.java
@@ -97,7 +97,7 @@ public class CreateAzureLandingZoneDbRecordStepTest {
               assertThat(
                   landingZone.billingProfileId(), equalTo(expectedLandingZone.billingProfileId()));
               assertThat(landingZone.region(), equalTo(expectedLandingZone.region()));
-              return expectedLandingZone.landingZoneId();
+              return landingZone.landingZoneId();
             });
     new CreateAzureLandingZoneDbRecordStep().doStep(context);
     verify(landingZoneDao).createLandingZone(any());


### PR DESCRIPTION
[WOR-1436](https://broadworkbench.atlassian.net/browse/WOR-1436)

This PR is for actually persisting the region to the landing zone.

It also cleans up access of the landing zone DAO, to get it from the flight context => `LandingZoneFlightBeanBag`, instead of the constructor.

[WOR-1436]: https://broadworkbench.atlassian.net/browse/WOR-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ