### PR TITLE
WOR-1478: get MRG when attaching a landing zone

### DIFF
--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneFlight.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneFlight.java
@@ -11,6 +11,7 @@ import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneRequest;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
 import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
 import bio.terra.landingzone.stairway.flight.create.resource.step.AggregateLandingZoneResourcesStep;
+import bio.terra.landingzone.stairway.flight.create.resource.step.GetManagedResourceGroupInfo;
 import bio.terra.landingzone.stairway.flight.exception.LandingZoneCreateException;
 import bio.terra.profile.model.ProfileModel;
 import bio.terra.stairway.*;
@@ -73,6 +74,17 @@ public class CreateLandingZoneFlight extends Flight {
 
       // last step to aggregate results
       addStep(new AggregateLandingZoneResourcesStep(), RetryRules.shortExponential());
+    } else {
+      // GetManagedResourceGroupInfo is needed when we *are* attaching, in order to create the db
+      // record
+      // armManagers is instantiated here separately to avoid disrupting tests that run on
+      // non-attach mode
+      // and that are expected to error before the armManagers are instantiated
+      // If we moved it outside the conditional block, it would happen before other logic in that
+      // branch,
+      // and fail for unexpected reasons
+      var armManagers = getArmManagers(flightBeanBag, inputParameters);
+      addStep(new GetManagedResourceGroupInfo(armManagers), RetryRules.cloud());
     }
 
     addStep(new CreateAzureLandingZoneDbRecordStep(), RetryRules.shortDatabase());

--- a/library/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneFlightTest.java
+++ b/library/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneFlightTest.java
@@ -11,6 +11,7 @@ import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneRequest;
 import bio.terra.landingzone.stairway.flight.FlightTestUtils;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
 import bio.terra.landingzone.stairway.flight.create.resource.step.BaseResourceCreateStep;
+import bio.terra.landingzone.stairway.flight.create.resource.step.GetManagedResourceGroupInfo;
 import bio.terra.landingzone.stairway.flight.exception.LandingZoneCreateException;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
@@ -18,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,6 +39,8 @@ class CreateLandingZoneFlightTest {
   // validating here only failed instantiation, otherwise it is required to
   // inject real value of tenant, subscription, mrg to initialize arm managers
 
+  @Disabled(
+      "adding GetManagedResourceGroupInfo requires us to initialize armManagers even when attaching to existing resources")
   @Test
   void testInitializationWhenAttaching() {
     final boolean isAttaching = true;
@@ -55,6 +59,8 @@ class CreateLandingZoneFlightTest {
 
   void validateSteps(List<Step> steps, boolean isAttaching) {
     assertThat(steps.stream().filter(s -> s instanceof CreateSamResourceStep).count(), equalTo(1L));
+    assertThat(
+        steps.stream().filter(s -> s instanceof GetManagedResourceGroupInfo).count(), equalTo(1L));
     if (!isAttaching) {
       // don't want to test for the exact number because it's perfectly valid that it can change
       // over time,


### PR DESCRIPTION
Adding the region to the landing zone created a new dependency on the `GetManagedResourceGroupInfo` step when attaching a landing zone to existing resources.
This adds the step in directly in the case that exists in order to support testing, in order to avoid changing the main code path, and so minimize the changes that need to be tested in this PR.