### PR TITLE
WOR-1515 Port Vault Secrets to Github Actions Secrets with Atlantis.

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -133,10 +133,9 @@ jobs:
         tag: ${{ steps.tag.outputs.tag }}
 
     - name: Auth to GCR
-      uses: google-github-actions/setup-gcloud@v0
+      uses: google-github-actions/auth@v0
       with:
-        service_account_email: ${{ secrets.GCR_PUBLISH_EMAIL }}
-        service_account_key: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
+        credentials_json: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
 
     - name: Explicitly auth Docker for GCR
       run: gcloud auth configure-docker --quiet

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -133,7 +133,7 @@ jobs:
         tag: ${{ steps.tag.outputs.tag }}
 
     - name: Auth to GCR
-      uses: google-github-actions/auth@v0
+      uses: google-github-actions/auth@v2
       with:
         credentials_json: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
 


### PR DESCRIPTION
Setup different github action for GCR authentication. The specified secret has been migrated already in this [PR](https://github.com/broadinstitute/terraform-ap-deployments/pull/1376)