### PR TITLE
[WOR-1535] Spring Boot dependency: pin postgresql to 42.7.2

### DIFF
--- a/buildSrc/src/main/groovy/bio.terra.landingzone.java-spring-app-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.landingzone.java-spring-app-conventions.gradle
@@ -4,3 +4,6 @@ plugins {
     id 'org.springframework.boot'
     id 'application'
 }
+
+// Spring Boot 3.1.2 pulls in postgresql 42.6.0, vulnerable to CVE-2024-1597
+ext['postgresql.version'] = '42.7.2'


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1535

Our current version of Spring Boot is [3.1.2](https://github.com/DataBiosphere/terra-landing-zone-service/blob/4a729a87adbabea21fde25a91162de329136b845/buildSrc/build.gradle#L18), which [brings in postgresql 42.6.0](https://github.com/spring-projects/spring-boot/blame/v3.1.2/spring-boot-project/spring-boot-dependencies/build.gradle#L1096-L1102).

To mitigate a security vulnerability, we must instruct Spring Boot use a non-vulnerable version.

I first tried upgrading our TCL to see if that would fix things but this had no impact: the Spring Boot pin was both necessary and sufficient, so I will pursue the TCL upgrade separately as it's a larger change.