### PR TITLE
[WOR-1586] Spring Boot 3.2.3, k8s client 20.0.1, TCL 1.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,12 +25,3 @@ updates:
       - "gradle"
     commit-message:
       prefix: "[WOR-1448]"
-    ignore:
-      - dependency-name: "org.springframework.boot:spring-boot-gradle-plugin"
-        update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
-      - dependency-name: "org.springframework.boot:spring-boot-starter-data-jdbc"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
-      - dependency-name: "org.springframework.boot:spring-boot-starter-web"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
-      - dependency-name: "org.springframework.boot:spring-boot-starter-test"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -15,7 +15,5 @@ dependencies {
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.4'
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.2'
     implementation 'org.sonarqube:org.sonarqube.gradle.plugin:4.4.1.3373'
-    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.1.2'
-    // This is required due to a dependency conflict between jib and srcclr. Removing it will cause jib to fail.
-    implementation 'org.apache.commons:commons-compress:1.26.1'
+    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.2.3'
 }

--- a/buildSrc/src/main/groovy/bio.terra.landingzone.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.landingzone.java-common-conventions.gradle
@@ -40,7 +40,6 @@ repositories {
 
 dependencies {
     compileOnly "com.google.code.findbugs:annotations:3.0.1"
-    implementation 'org.slf4j:slf4j-api'
     implementation 'io.swagger.core.v3:swagger-annotations:2.1.12'
     implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.2.0'
     // Needed for @VisibleForTesting and more:
@@ -50,10 +49,7 @@ dependencies {
     implementation 'com.google.guava:guava:33.1.0-jre'
     swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.47'
 
-    testImplementation 'ch.qos.logback:logback-classic'
-    testImplementation 'org.hamcrest:hamcrest:2.2'
-
-    implementation ('bio.terra:terra-common-lib:1.0.10-SNAPSHOT') {
+    implementation ('bio.terra:terra-common-lib:1.1.0-SNAPSHOT') {
         exclude group: "org.broadinstitute.dsde.workbench", module: "sam-client_2.13"
     }
 }

--- a/buildSrc/src/main/groovy/bio.terra.landingzone.java-spring-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.landingzone.java-spring-conventions.gradle
@@ -4,8 +4,6 @@ plugins {
     id 'org.springframework.boot'
 }
 
-// Spring Boot 3.1.2 pulls in postgresql 42.6.0, vulnerable to CVE-2024-1597
-ext['postgresql.version'] = '42.7.2'
-// Spring Boot 3.1.2 pulls in opentelemetry-bom 1.25.0.
-// It must have version >= 1.34.1 for compatibility with terra-common-lib 1.0.9:
+// Spring Boot 3.2.3 pulls in opentelemetry-bom 1.31.0.
+// It must have version >= 1.34.1 for compatibility with terra-common-lib 1.1.0:
 ext['opentelemetry.version'] = '1.36.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     api 'org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-6d19a41'
     implementation 'bio.terra:billing-profile-manager-client:0.1.484-SNAPSHOT'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api'
-    implementation 'org.postgresql:postgresql:42.7.2'
     implementation group: 'com.azure', name: 'azure-core', version: '1.47.0'
     implementation (group: 'com.azure', name: 'azure-identity', version: '1.11.3') {
         // azure-identity is still pulling in an old version of reactor-netty-http
@@ -41,25 +40,11 @@ dependencies {
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-applicationinsights', version: '1.0.0'
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-securityinsights', version: '1.0.0-beta.4'
 
-    implementation group: "io.kubernetes", name: "client-java", version: "20.0.0-legacy"
-    // io.kubernetes:client-java brings in snakeyaml 2.0 which breaks whatever version of liquibase was pulled in before
-    implementation group: 'org.liquibase', name: 'liquibase-core', version: '4.26.0'
+    implementation group: "io.kubernetes", name: "client-java", version: "20.0.1"
     implementation group: 'io.micrometer', name: 'micrometer-registry-prometheus', version: '1.12.3'
 
-    liquibaseRuntime 'org.liquibase:liquibase-core:4.26.0'
-    liquibaseRuntime 'info.picocli:picocli:4.7.5'
-    liquibaseRuntime 'org.postgresql:postgresql:42.7.2'
-    liquibaseRuntime 'ch.qos.logback:logback-classic'
-
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
-
     testImplementation 'org.mockito:mockito-inline:5.2.0'
-    testImplementation 'org.awaitility:awaitility:4.2.0'
-    testImplementation('org.springframework.boot:spring-boot-starter-test') {
-        // Fixes warning about multiple occurrences of JSONObject on the classpath
-        exclude group: 'com.vaadin.external.google', module: 'android-json'
-    }
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 // We use Spring Boot gradle plugin in a non-Spring Boot environment to manage Spring Boot dependency.

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateLandingZoneFederatedIdentityStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateLandingZoneFederatedIdentityStep.java
@@ -90,7 +90,7 @@ public class CreateLandingZoneFederatedIdentityStep implements Step {
                     .name(uamiName) // name of the service account is the same as the user-assigned
                     .namespace(k8sNamespace));
 
-    api.createNamespacedServiceAccount(k8sNamespace, aksServiceAccount, null, null, null, null);
+    api.createNamespacedServiceAccount(k8sNamespace, aksServiceAccount).execute();
   }
 
   private void deleteK8sServiceAccount(
@@ -99,8 +99,9 @@ public class CreateLandingZoneFederatedIdentityStep implements Step {
     CoreV1Api api =
         kubernetesClientProvider.createCoreApiClient(armManagers, mrgName, aksClusterName);
 
-    api.deleteNamespacedServiceAccount(
-        uamiName, k8sNamespace, null, null, null, null, null, new V1DeleteOptions());
+    api.deleteNamespacedServiceAccount(uamiName, k8sNamespace)
+        .body(new V1DeleteOptions())
+        .execute();
   }
 
   private void createFederatedCredentials(

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/EnableAksContainerLogV2Step.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/EnableAksContainerLogV2Step.java
@@ -94,8 +94,7 @@ public class EnableAksContainerLogV2Step implements Step {
     CoreV1Api k8sApiClient =
         kubernetesClientProvider.createCoreApiClient(
             armManagers, managedResourceGroupName, aksResourceName);
-    k8sApiClient.createNamespacedConfigMap(
-        aksNamespace, containerLogV2ConfigMap, null, null, null, null);
+    k8sApiClient.createNamespacedConfigMap(aksNamespace, containerLogV2ConfigMap).execute();
   }
 
   private boolean isK8sApiRetryableError(int httpStatusCode) {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -28,10 +28,7 @@ dependencies {
     implementation 'org.springframework:spring-aop'
     implementation 'org.springframework:spring-aspects'
 
-    //implementation group: "org.liquibase", name: "liquibase-core", version: "4.8.0"
-
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation group: "org.hamcrest", name: "hamcrest", version: "2.2"
 
     testImplementation 'au.com.dius.pact.consumer:junit5:4.6.7'
     testImplementation("au.com.dius.pact.provider:junit5:4.6.7")

--- a/testharness/build.gradle
+++ b/testharness/build.gradle
@@ -3,13 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation (project(":library")) {
-        // the msal4j transitive dependency is still pulling in an old version of json-smart
-        // which is vulnerable to CVE-2023-1370
-        // see https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/611
-        exclude group: 'net.minidev', module: 'json-smart'
-    }
-    implementation 'net.minidev:json-smart:2.5.0'
+    implementation project(":library")
 
     implementation 'org.apache.commons:commons-dbcp2'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
@@ -18,13 +12,7 @@ dependencies {
     implementation 'org.springframework:spring-aop'
     implementation 'org.springframework:spring-aspects'
 
-    testImplementation 'org.apache.commons:commons-lang3:3.14.0'
-
-    testImplementation('org.springframework.boot:spring-boot-starter-test') {
-        exclude group: 'com.vaadin.external.google', module: 'android-json'
-        exclude group: 'net.minidev', module: 'json-smart'
-    }
-    testImplementation group: "org.hamcrest", name: "hamcrest", version: "2.2"
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     // Allows us to mock final classes
     testImplementation 'org.mockito:mockito-inline:5.2.0'


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1587

**Dependency Upgrades**

This PR undertakes a number of dependency upgrades:

- Spring Boot 3.1.2 -> 3.2.3
- `io.kubernetes:client-java` 20.0.0-legacy -> 20.0.1
  - This upgrade contains breaking changes: optional parameters are now consolidated into a single object, and we must explicitly execute our requests.
  - Christina started down the path of addressing them in : [[WOR-1448]: Bump the minor-patch-dependencies group with 8 updates by dependabot[bot] · Pull Request #423 · DataBiosphere/terra-landing-zone-service](https://github.com/DataBiosphere/terra-landing-zone-service/pull/423), but we decided to break this out due to the heightened risk.
- `bio.terra:terra-common-lib` 1.0.10-SNAPSHOT -> 1.1.0-SNAPSHOT
  - This upgrade contains TCL's own k8s client upgrade to 20.0.1.  We previously tried to upgrade WSM’s k8s client to 20.0.1, but didn’t also upgrade TCL to 1.1.0: deployment to dev failed due to the incompatibility.
  
**Dependency Cleanup**

While scrutinizing our dependencies over the course of applying these upgrades, I found many places where we can remove dependency definitions.

Many dependencies were already pulled in and versioned through Spring Boot dependency manager and starter packages, and some past version pins to address vulnerabilities are no longer necessary.

(TBD: looking into running a Veracode scan on this feature branch to confirm no regressions to past vulnerabilities, along with confirmation of what's been fixed.)

**Dependabot for Spring Boot upgrades**

One of the most impactful things we can do to stay on top of vulnerable dependencies is to keep Spring Boot up to date.  We use Spring's dependency manager and pull in many of its starter packages as dependencies, so as Spring Boot addresses vulnerabilities on its ends we'd like to get them for free, rather than be tempted to pin versions solely for the purpose of mitigating a vulnerability.

So, I've adjusted our Dependabot settings to stop ignoring Spring Boot updates.  We can revisit these in the future if we want to break them out of the grouped minor and patch update PRs into standalone PRs for extra attention.

[WOR-1448]: https://broadworkbench.atlassian.net/browse/WOR-1448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ