### PR TITLE
WOR-1598 Stop publishing unapproved changes in LZS.

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -118,6 +118,7 @@ jobs:
       run: chmod +x gradlew
 
     - name: Publish to Artifactory
+      if: ${{ github.ref_name == 'main' }}
       run: ./gradlew :library:artifactoryPublish --scan
       env:
         ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
@@ -125,6 +126,7 @@ jobs:
         ARTIFACTORY_REPO_KEY: "libs-snapshot-local"
 
     - name: Publish API client
+      if: ${{ github.ref_name == 'main' }}
       run: ./gradlew :client:artifactoryPublish
       env:
         ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}


### PR DESCRIPTION
I left `pull_request` option since publishing custom app version might be really helpful for BEE deployment.
Instead, I added condition for publishing artifacts.

![image](https://github.com/DataBiosphere/terra-landing-zone-service/assets/91149690/7e9be15b-2615-45f7-80b9-53d3cac1f748)
