### PR TITLE
[PF-3000] TCL 1.1.4, k8s client 20.0.1-legacy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,6 @@ updates:
       - "gradle"
     commit-message:
       prefix: "[WOR-1448]"
+    ignore:
+      # PF-3000: k8s client versions 20.0.0 onward without '-legacy' suffix include breaking changes
+      - dependency-name: "io.kubernetes:client-java"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,3 +55,37 @@ Running integration tests locally requires:
 ### Smoke tests
 
 For information on executing smoke tests to check that the Landing Zone service is operational in a given environment, see the smoke test [README.md](./smoke_tests/README.md).
+
+
+## SourceClear
+
+[SourceClear](https://srcclr.github.io) is a static analysis tool that scans a project's Java
+dependencies for known vulnerabilities. If you are working on addressing dependency vulnerabilities
+in response to a SourceClear finding, you may want to run a scan off of a feature branch and/or local code.
+
+### Github Action
+
+You can trigger LZS's SCA scan on demand via its
+[Github Action](https://github.com/broadinstitute/dsp-appsec-sourceclear-github-actions/actions/workflows/z-manual-terra-landing-zone-service.yml),
+and optionally specify a Github ref (branch, tag, or SHA) to check out from the repo to scan.  By default,
+the scan is run off of LZS's `main` branch.
+
+High-level results are outputted in the Github Actions run.
+
+### Running Locally
+
+You will need to get the API token from Vault before running the Gradle `srcclr` task.
+
+```sh
+export SRCCLR_API_TOKEN=$(vault read -field=api_token secret/secops/ci/srcclr/gradle-agent)
+./gradlew srcclr
+```
+
+High-level results are outputted to the terminal.
+
+### Veracode
+
+Full results including dependency graphs are uploaded to
+[Veracode](https://sca.analysiscenter.veracode.com/workspaces/jppForw/projects/554814/issues)
+(if running off of a feature branch, navigate to Project Details > Selected Branch > Change to select your feature branch).
+You can request a Veracode account to view full results from #dsp-infosec-champions.

--- a/buildSrc/src/main/groovy/bio.terra.landingzone.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.landingzone.java-common-conventions.gradle
@@ -5,6 +5,7 @@ plugins {
 
     id 'com.diffplug.spotless'
     id 'org.hidetake.swagger.generator'
+    id 'com.srcclr.gradle'
 }
 
 boolean isGithubAction = System.getenv().containsKey("GITHUB_ACTIONS")
@@ -54,7 +55,7 @@ dependencies {
     implementation 'com.google.guava:guava:33.1.0-jre'
     swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.47'
 
-    implementation ('bio.terra:terra-common-lib:1.1.1-SNAPSHOT') {
+    implementation ('bio.terra:terra-common-lib:1.1.4-SNAPSHOT') {
         exclude group: "org.broadinstitute.dsde.workbench", module: "sam-client_2.13"
     }
 }
@@ -89,4 +90,8 @@ compileJava {
     } else {
         dependsOn(spotlessApply)
     }
+}
+
+srcclr {
+    scope = "runtimeClasspath"
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'bio.terra.landingzone.java-spring-library-conventions'
     id 'de.undercouch.download'
     id 'com.google.cloud.tools.jib'
-    id 'com.srcclr.gradle'
     id 'org.sonarqube'
     id 'com.jfrog.artifactory'
     id 'org.liquibase.gradle' version '2.2.1'
@@ -40,7 +39,8 @@ dependencies {
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-applicationinsights', version: '1.0.0'
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-securityinsights', version: '1.0.0-beta.4'
 
-    implementation group: "io.kubernetes", name: "client-java", version: "20.0.1"
+    // PF-3000: k8s client versions 20.0.0 onward without '-legacy' suffix include breaking changes
+    implementation group: 'io.kubernetes', name: 'client-java', version: '20.0.1-legacy' // keep legacy suffix
     implementation group: 'io.micrometer', name: 'micrometer-registry-prometheus', version: '1.12.4'
 
     testImplementation 'org.mockito:mockito-inline:5.2.0'

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateLandingZoneFederatedIdentityStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateLandingZoneFederatedIdentityStep.java
@@ -90,7 +90,7 @@ public class CreateLandingZoneFederatedIdentityStep implements Step {
                     .name(uamiName) // name of the service account is the same as the user-assigned
                     .namespace(k8sNamespace));
 
-    api.createNamespacedServiceAccount(k8sNamespace, aksServiceAccount).execute();
+    api.createNamespacedServiceAccount(k8sNamespace, aksServiceAccount, null, null, null, null);
   }
 
   private void deleteK8sServiceAccount(
@@ -99,9 +99,8 @@ public class CreateLandingZoneFederatedIdentityStep implements Step {
     CoreV1Api api =
         kubernetesClientProvider.createCoreApiClient(armManagers, mrgName, aksClusterName);
 
-    api.deleteNamespacedServiceAccount(uamiName, k8sNamespace)
-        .body(new V1DeleteOptions())
-        .execute();
+    api.deleteNamespacedServiceAccount(
+        uamiName, k8sNamespace, null, null, null, null, null, new V1DeleteOptions());
   }
 
   private void createFederatedCredentials(

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/EnableAksContainerLogV2Step.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/resource/step/EnableAksContainerLogV2Step.java
@@ -94,7 +94,8 @@ public class EnableAksContainerLogV2Step implements Step {
     CoreV1Api k8sApiClient =
         kubernetesClientProvider.createCoreApiClient(
             armManagers, managedResourceGroupName, aksResourceName);
-    k8sApiClient.createNamespacedConfigMap(aksNamespace, containerLogV2ConfigMap).execute();
+    k8sApiClient.createNamespacedConfigMap(
+        aksNamespace, containerLogV2ConfigMap, null, null, null, null);
   }
 
   private boolean isK8sApiRetryableError(int httpStatusCode) {

--- a/library/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateLandingZoneFederatedIdentityStepTest.java
+++ b/library/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/CreateLandingZoneFederatedIdentityStepTest.java
@@ -20,7 +20,6 @@ import com.azure.resourcemanager.msi.fluent.models.FederatedIdentityCredentialIn
 import com.azure.resourcemanager.msi.models.Identities;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
-import io.kubernetes.client.openapi.models.V1DeleteOptions;
 import io.kubernetes.client.openapi.models.V1ServiceAccount;
 import java.util.List;
 import java.util.Map;
@@ -46,14 +45,6 @@ public class CreateLandingZoneFederatedIdentityStepTest extends BaseStepTest {
   @Mock FederatedIdentityCredentialsClient mockFederatedIdentityCredentials;
   @Captor private ArgumentCaptor<FederatedIdentityCredentialInner> federatedIdentityCaptor;
   @Mock private CoreV1Api mockKubernetesClient;
-
-  @Mock
-  private CoreV1Api.APIdeleteNamespacedServiceAccountRequest
-      mockDeleteNamespacedServiceAccountRequest;
-
-  @Mock
-  private CoreV1Api.APIcreateNamespacedServiceAccountRequest
-      mockCreateNamespacedServiceAccountRequest;
 
   @Captor private ArgumentCaptor<V1ServiceAccount> serviceAccountCaptor;
 
@@ -101,8 +92,6 @@ public class CreateLandingZoneFederatedIdentityStepTest extends BaseStepTest {
     assertThat(serviceAccountCaptor.getValue().getMetadata().getName(), equalTo(uamiName));
     assertThat(serviceAccountCaptor.getValue().getMetadata().getNamespace(), equalTo(k8sNamespace));
 
-    verify(mockCreateNamespacedServiceAccountRequest).execute();
-
     assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
   }
 
@@ -133,19 +122,18 @@ public class CreateLandingZoneFederatedIdentityStepTest extends BaseStepTest {
 
     when(mockKubernetesClientProvider.createCoreApiClient(any(), any(), any()))
         .thenReturn(mockKubernetesClient);
-    when(mockKubernetesClient.deleteNamespacedServiceAccount(uamiName, k8sNamespace))
-        .thenReturn(mockDeleteNamespacedServiceAccountRequest);
-    when(mockDeleteNamespacedServiceAccountRequest.body(new V1DeleteOptions()))
-        .thenReturn(mockDeleteNamespacedServiceAccountRequest);
 
     var stepResult = testStep.undoStep(mockFlightContext);
 
     assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
-    verify(mockDeleteNamespacedServiceAccountRequest).execute();
+    verify(mockKubernetesClient)
+        .deleteNamespacedServiceAccount(
+            eq(uamiName), eq(k8sNamespace), any(), any(), any(), any(), any(), any());
     verify(mockFederatedIdentityCredentials).delete(mrg.name(), uamiName, uamiName);
   }
 
-  private void setupArmManagersForDoStep(String uamiName, TargetManagedResourceGroup mrg) {
+  private void setupArmManagersForDoStep(String uamiName, TargetManagedResourceGroup mrg)
+      throws ApiException {
     when(mockArmManagers.azureResourceManager()).thenReturn(mockAzureResourceManager);
     when(mockAzureResourceManager.identities()).thenReturn(mockIdentities);
     when(mockIdentities.manager()).thenReturn(mockManager);
@@ -159,7 +147,7 @@ public class CreateLandingZoneFederatedIdentityStepTest extends BaseStepTest {
     when(mockKubernetesClientProvider.createCoreApiClient(any(), any(), any()))
         .thenReturn(mockKubernetesClient);
     when(mockKubernetesClient.createNamespacedServiceAccount(
-            eq(k8sNamespace), serviceAccountCaptor.capture()))
-        .thenReturn(mockCreateNamespacedServiceAccountRequest);
+            eq(k8sNamespace), serviceAccountCaptor.capture(), any(), any(), any(), any()))
+        .thenReturn(null);
   }
 }

--- a/library/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/EnableAksContainerLogV2StepTest.java
+++ b/library/src/test/java/bio/terra/landingzone/stairway/flight/create/resource/step/EnableAksContainerLogV2StepTest.java
@@ -4,6 +4,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -42,7 +44,6 @@ class EnableAksContainerLogV2StepTest extends BaseStepTest {
   @Mock private KubernetesClientProvider mockKubernetesClientProvider;
   @Mock private AksConfigMapReader mockAksConfigMapReader;
   @Mock private CoreV1Api mockCoreV1Api;
-  @Mock private CoreV1Api.APIcreateNamespacedConfigMapRequest mockCreateNamespacedConfigMapRequest;
 
   @Captor private ArgumentCaptor<String> aksNameCaptor;
   @Captor private ArgumentCaptor<String> mrgNameCaptor;
@@ -75,8 +76,9 @@ class EnableAksContainerLogV2StepTest extends BaseStepTest {
     when(mockKubernetesClientProvider.createCoreApiClient(
             any(), mrgNameCaptor.capture(), aksNameCaptor.capture()))
         .thenReturn(mockCoreV1Api);
-    when(mockCoreV1Api.createNamespacedConfigMap(aksNamespaceCaptor.capture(), any()))
-        .thenReturn(mockCreateNamespacedConfigMapRequest);
+    when(mockCoreV1Api.createNamespacedConfigMap(
+            aksNamespaceCaptor.capture(), any(), any(), any(), any(), any()))
+        .thenReturn(null);
 
     var stepResult = testStep.doStep(mockFlightContext);
 
@@ -85,7 +87,8 @@ class EnableAksContainerLogV2StepTest extends BaseStepTest {
     assertThat(mrgNameCaptor.getValue(), equalTo(targetMrg.name()));
     assertThat(aksNameCaptor.getValue(), equalTo(aksClusterName));
     verify(mockAksConfigMapReader, times(1)).read();
-    verify(mockCreateNamespacedConfigMapRequest).execute();
+    verify(mockCoreV1Api, times(1))
+        .createNamespacedConfigMap(anyString(), any(), eq(null), eq(null), eq(null), eq(null));
     assertThat(aksNamespaceCaptor.getValue(), equalTo("kube-system"));
   }
 
@@ -118,12 +121,12 @@ class EnableAksContainerLogV2StepTest extends BaseStepTest {
     when(mockKubernetesClientProvider.createCoreApiClient(
             any(), mrgNameCaptor.capture(), aksNameCaptor.capture()))
         .thenReturn(mockCoreV1Api);
-    when(mockCoreV1Api.createNamespacedConfigMap(any(), any()))
-        .thenReturn(mockCreateNamespacedConfigMapRequest);
 
     var apiNonRetryableException = mock(ApiException.class);
     when(apiNonRetryableException.getCode()).thenReturn(HttpStatus.LOOP_DETECTED.value());
-    doThrow(apiNonRetryableException).when(mockCreateNamespacedConfigMapRequest).execute();
+    doThrow(apiNonRetryableException)
+        .when(mockCoreV1Api)
+        .createNamespacedConfigMap(any(), any(), any(), any(), any(), any());
 
     var stepResult = testStep.doStep(mockFlightContext);
     assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'bio.terra.landingzone.java-spring-app-conventions'
     id 'de.undercouch.download'
     id 'com.google.cloud.tools.jib'
-    id 'com.srcclr.gradle'
     id 'com.gorylenko.gradle-git-properties' version '2.4.1'
     id "au.com.dius.pact" version "4.6.8"
 }


### PR DESCRIPTION
Move LZS back to using the legacy version of the k8s client to match what is in TCL 1.1.4.  The non-legacy version yielded a breaking change in TCL's KubePodListener.

Instruct Dependabot to ignore k8s client upgrades.

Finished wiring in srcclr plug-in (an additional block of config was required to run it), added instructions for running scans off of local code and feature branches.

Note: hang back before putting this up for review, in case Doug figures out how to fix our k8s client usage in TCL.