### PR TITLE
[WOR-1448] Upgrade TCL 1.1.1 -> 1.1.6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,10 @@ updates:
       - "gradle"
     commit-message:
       prefix: "[WOR-1448]"
+    ignore:
+      # From 20.0.0 onward, k8s client publishes versions with and without '-legacy' suffix.
+      # We use the non-legacy client: the legacy client is not compatible with our code.
+      # Dependabot doesn't have an option for ignoring versions conforming to a naming convention
+      # (outside of semver major, minor, and patch designations) and will attempt to update
+      # to the latest published version.
+      - dependency-name: "io.kubernetes:client-java"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,3 +55,37 @@ Running integration tests locally requires:
 ### Smoke tests
 
 For information on executing smoke tests to check that the Landing Zone service is operational in a given environment, see the smoke test [README.md](./smoke_tests/README.md).
+
+
+## SourceClear
+
+[SourceClear](https://srcclr.github.io) is a static analysis tool that scans a project's Java
+dependencies for known vulnerabilities.x If you are working on addressing dependency vulnerabilities
+in response to a SourceClear finding, you may want to run a scan off of a feature branch and/or local code.
+
+### Github Action
+
+You can trigger LZS's SCA scan on demand via its
+[Github Action](https://github.com/broadinstitute/dsp-appsec-sourceclear-github-actions/actions/workflows/z-manual-terra-landing-zone-service.yml),
+and optionally specify a Github ref (branch, tag, or SHA) to check out from the repo to scan.  By default,
+the scan is run off of LZS's `main` branch.
+
+High-level results are outputted in the Github Actions run.
+
+### Running Locally
+
+You will need to get the API token from Vault before running the Gradle `srcclr` task.
+
+```sh
+export SRCCLR_API_TOKEN=$(vault read -field=api_token secret/secops/ci/srcclr/gradle-agent)
+./gradlew srcclr
+```
+
+High-level results are outputted to the terminal.
+
+### Veracode
+
+Full results including dependency graphs are uploaded to
+[Veracode](https://sca.analysiscenter.veracode.com/workspaces/jppForw/projects/554814/issues)
+(if running off of a feature branch, navigate to Project Details > Selected Branch > Change to select your feature branch).
+You can request a Veracode account to view full results from #dsp-infosec-champions.

--- a/buildSrc/src/main/groovy/bio.terra.landingzone.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.landingzone.java-common-conventions.gradle
@@ -5,6 +5,7 @@ plugins {
 
     id 'com.diffplug.spotless'
     id 'org.hidetake.swagger.generator'
+    id 'com.srcclr.gradle'
 }
 
 boolean isGithubAction = System.getenv().containsKey("GITHUB_ACTIONS")
@@ -54,7 +55,7 @@ dependencies {
     implementation 'com.google.guava:guava:33.1.0-jre'
     swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.47'
 
-    implementation ('bio.terra:terra-common-lib:1.1.1-SNAPSHOT') {
+    implementation ('bio.terra:terra-common-lib:1.1.6-SNAPSHOT') {
         exclude group: "org.broadinstitute.dsde.workbench", module: "sam-client_2.13"
     }
 }
@@ -89,4 +90,8 @@ compileJava {
     } else {
         dependsOn(spotlessApply)
     }
+}
+
+srcclr {
+    scope = "runtimeClasspath"
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-applicationinsights', version: '1.0.0'
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-securityinsights', version: '1.0.0-beta.4'
 
-    implementation group: "io.kubernetes", name: "client-java", version: "20.0.1"
+    implementation group: "io.kubernetes", name: "client-java", version: "20.0.1" // Do not use -legacy versions
     implementation group: 'io.micrometer', name: 'micrometer-registry-prometheus', version: '1.12.4'
 
     testImplementation 'org.mockito:mockito-inline:5.2.0'

--- a/service/src/test/java/bio/terra/lz/futureservice/app/controller/LandingZoneApiControllerTest.java
+++ b/service/src/test/java/bio/terra/lz/futureservice/app/controller/LandingZoneApiControllerTest.java
@@ -311,6 +311,8 @@ public class LandingZoneApiControllerTest extends BaseSpringUnitTest {
 
   @Test
   void getAzureLandingZoneByLandingZoneIdSuccess() throws Exception {
+    // Defining a fixed Instant to 3 decimal places (no trailing zeros).
+    // This is so that our later String acomparison is performed at the same granularity:
     var lzCreateDate = Instant.parse("2024-04-01T12:34:56.789Z").atOffset(ZoneOffset.UTC);
     ApiAzureLandingZone landingZone =
         AzureLandingZoneFixtures.buildDefaultApiAzureLandingZone(

--- a/service/src/test/java/bio/terra/lz/futureservice/app/controller/LandingZoneApiControllerTest.java
+++ b/service/src/test/java/bio/terra/lz/futureservice/app/controller/LandingZoneApiControllerTest.java
@@ -32,7 +32,6 @@ import bio.terra.lz.futureservice.generated.model.ApiJobReport;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
 import java.time.ZoneOffset;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -312,8 +311,7 @@ public class LandingZoneApiControllerTest extends BaseSpringUnitTest {
 
   @Test
   void getAzureLandingZoneByLandingZoneIdSuccess() throws Exception {
-    // Truncating to milliseconds so that our later comparison is performed at the same granularity.
-    var lzCreateDate = Instant.now().truncatedTo(ChronoUnit.MILLIS).atOffset(ZoneOffset.UTC);
+    var lzCreateDate = Instant.parse("2024-04-01T12:34:56.789Z").atOffset(ZoneOffset.UTC);
     ApiAzureLandingZone landingZone =
         AzureLandingZoneFixtures.buildDefaultApiAzureLandingZone(
             LANDING_ZONE_ID, BILLING_PROFILE_ID, "definition", "version", lzCreateDate);

--- a/service/src/test/java/bio/terra/lz/futureservice/app/controller/LandingZoneApiControllerTest.java
+++ b/service/src/test/java/bio/terra/lz/futureservice/app/controller/LandingZoneApiControllerTest.java
@@ -312,7 +312,7 @@ public class LandingZoneApiControllerTest extends BaseSpringUnitTest {
   @Test
   void getAzureLandingZoneByLandingZoneIdSuccess() throws Exception {
     // Defining a fixed Instant to 3 decimal places (no trailing zeros).
-    // This is so that our later String acomparison is performed at the same granularity:
+    // This is so that our later String comparison is performed at the same granularity:
     var lzCreateDate = Instant.parse("2024-04-01T12:34:56.789Z").atOffset(ZoneOffset.UTC);
     ApiAzureLandingZone landingZone =
         AzureLandingZoneFixtures.buildDefaultApiAzureLandingZone(


### PR DESCRIPTION
This TCL version includes KubePodListener fixes to work with the non-legacy k8s client.  Related PR: DataBiosphere/terra-common-lib#174

Instruct Dependabot to ignore k8s client upgrades.  The client is publishing legacy and non-legacy versions, and Dependabot tries to update to the latest published version.

Finished wiring in srcclr plug-in (an additional block of config was required to run it), added instructions for running scans off of local code and feature branches.