### PR TITLE
[WOR-1448] Pin Spring dependency manager's netty version to 4.1.108.Final

### DIFF
--- a/buildSrc/src/main/groovy/bio.terra.landingzone.java-spring-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.landingzone.java-spring-conventions.gradle
@@ -7,3 +7,5 @@ plugins {
 // Spring Boot 3.2.3 pulls in opentelemetry-bom 1.31.0.
 // It must have version >= 1.34.1 for compatibility with terra-common-lib 1.1.0:
 ext['opentelemetry.version'] = '1.36.0'
+// Spring Boot 3.2.3 pulls in io.netty:netty-bom 4.1.107.Final which is impacted by CVE-2024-29025.
+ext['netty.version'] = '4.1.108.Final'


### PR DESCRIPTION
I've added a pin to override Spring Boot 3.2.3's netty dependencies versioned at [io.netty:netty-handler:4.1.107.Final](https://github.com/spring-projects/spring-boot/blob/v3.2.3/spring-boot-project/spring-boot-dependencies/build.gradle#L1084-L1090) which contain vulnerabilities. Other dependencies may also pull in these transitive dependencies, but the Spring dependency manager version clobbers them all.

If Spring Boot upgrades this on their end in a future release (they haven't done so yet in 3.2.4), you can remove the pin.

### Verification of Impact on Vulnerabilities

Here is a [GHA Veracode](https://github.com/broadinstitute/dsp-appsec-sourceclear-github-actions/actions/runs/8545717883/job/23414607450) scan that I manually triggered off of this feature branch.

Comparison against the last scan run off of the `main` branch:

- Risk score 16/100 -> 0/100 🎉
- Open issues 22 -> 21 (includes out-of-date libraries)
- Vulnerabilities 2 -> 0 🎉