### PR TITLE
[WOR-1127] Include region in landing zone responses

### DIFF
--- a/service/src/main/java/bio/terra/lz/futureservice/app/service/LandingZoneAppService.java
+++ b/service/src/main/java/bio/terra/lz/futureservice/app/service/LandingZoneAppService.java
@@ -245,6 +245,7 @@ public class LandingZoneAppService {
         .landingZoneId(landingZone.landingZoneId())
         .definition(landingZone.definition())
         .version(landingZone.version())
+        .region(landingZone.region())
         .createdDate(landingZone.createdDate());
   }
 

--- a/service/src/test/java/bio/terra/lz/futureservice/app/controller/LandingZoneApiControllerTest.java
+++ b/service/src/test/java/bio/terra/lz/futureservice/app/controller/LandingZoneApiControllerTest.java
@@ -316,7 +316,12 @@ public class LandingZoneApiControllerTest extends BaseSpringUnitTest {
     var lzCreateDate = Instant.parse("2024-04-01T12:34:56.789Z").atOffset(ZoneOffset.UTC);
     ApiAzureLandingZone landingZone =
         AzureLandingZoneFixtures.buildDefaultApiAzureLandingZone(
-            LANDING_ZONE_ID, BILLING_PROFILE_ID, "definition", "version", lzCreateDate);
+            LANDING_ZONE_ID,
+            BILLING_PROFILE_ID,
+            "definition",
+            "version",
+            lzCreateDate,
+            "southcentralus");
     when(mockLandingZoneAppService.getAzureLandingZone(any(), eq(LANDING_ZONE_ID)))
         .thenReturn(landingZone);
     mockMvc
@@ -332,12 +337,14 @@ public class LandingZoneApiControllerTest extends BaseSpringUnitTest {
         .andExpect(MockMvcResultMatchers.jsonPath("$.version").exists())
         .andExpect(MockMvcResultMatchers.jsonPath("$.version", equalTo("version")))
         .andExpect(MockMvcResultMatchers.jsonPath("$.billingProfileId").exists())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.region").exists())
         .andExpect(
             MockMvcResultMatchers.jsonPath(
                 "$.billingProfileId", equalTo(BILLING_PROFILE_ID.toString())))
         .andExpect(MockMvcResultMatchers.jsonPath("$.createdDate").exists())
-        .andExpect(
-            MockMvcResultMatchers.jsonPath("$.createdDate", equalTo(lzCreateDate.toString())));
+        .andExpect(MockMvcResultMatchers.jsonPath("$.createdDate", equalTo("southcentralus")))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.region").exists())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.region", equalTo("southcentralus")));
   }
 
   @Test
@@ -345,7 +352,12 @@ public class LandingZoneApiControllerTest extends BaseSpringUnitTest {
     var lzCreateDate = Instant.now().atOffset(ZoneOffset.UTC);
     var landingZone =
         AzureLandingZoneFixtures.buildDefaultApiAzureLandingZone(
-            LANDING_ZONE_ID, BILLING_PROFILE_ID, "definition", "version", lzCreateDate);
+            LANDING_ZONE_ID,
+            BILLING_PROFILE_ID,
+            "definition",
+            "version",
+            lzCreateDate,
+            "southcentralus");
     ApiAzureLandingZoneList landingZoneList =
         new ApiAzureLandingZoneList().landingzones(List.of(landingZone));
 
@@ -377,7 +389,10 @@ public class LandingZoneApiControllerTest extends BaseSpringUnitTest {
         .andExpect(MockMvcResultMatchers.jsonPath("$.landingzones[0].createdDate").exists())
         .andExpect(
             MockMvcResultMatchers.jsonPath(
-                "$.landingzones[0].createdDate", equalTo(lzCreateDate.toString())));
+                "$.landingzones[0].createdDate", equalTo(lzCreateDate.toString())))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.landingzones[0].region").exists())
+        .andExpect(
+            MockMvcResultMatchers.jsonPath("$.landingzones[0].region", equalTo("southcentralus")));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/lz/futureservice/app/controller/LandingZoneApiControllerTest.java
+++ b/service/src/test/java/bio/terra/lz/futureservice/app/controller/LandingZoneApiControllerTest.java
@@ -342,7 +342,8 @@ public class LandingZoneApiControllerTest extends BaseSpringUnitTest {
             MockMvcResultMatchers.jsonPath(
                 "$.billingProfileId", equalTo(BILLING_PROFILE_ID.toString())))
         .andExpect(MockMvcResultMatchers.jsonPath("$.createdDate").exists())
-        .andExpect(MockMvcResultMatchers.jsonPath("$.createdDate", equalTo("southcentralus")))
+        .andExpect(
+            MockMvcResultMatchers.jsonPath("$.createdDate", equalTo(lzCreateDate.toString())))
         .andExpect(MockMvcResultMatchers.jsonPath("$.region").exists())
         .andExpect(MockMvcResultMatchers.jsonPath("$.region", equalTo("southcentralus")));
   }

--- a/service/src/test/java/bio/terra/lz/futureservice/common/fixture/AzureLandingZoneFixtures.java
+++ b/service/src/test/java/bio/terra/lz/futureservice/common/fixture/AzureLandingZoneFixtures.java
@@ -129,12 +129,14 @@ public class AzureLandingZoneFixtures {
       UUID billingProfileId,
       String definition,
       String version,
-      OffsetDateTime createDate) {
+      OffsetDateTime createDate,
+      String region) {
     return new ApiAzureLandingZone()
         .landingZoneId(landingZoneId)
         .billingProfileId(billingProfileId)
         .definition(definition)
         .version(version)
+        .region(region)
         .createdDate(createDate);
   }
 


### PR DESCRIPTION
Region is required by WSM, it must be included in LZ details returned from the service.