### PR TITLE
Reenable test

### DIFF
--- a/service/src/test/java/bio/terra/lz/futureservice/app/controller/LandingZoneApiControllerTest.java
+++ b/service/src/test/java/bio/terra/lz/futureservice/app/controller/LandingZoneApiControllerTest.java
@@ -31,12 +31,12 @@ import bio.terra.lz.futureservice.generated.model.ApiDeleteAzureLandingZoneResul
 import bio.terra.lz.futureservice.generated.model.ApiJobReport;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -349,10 +349,9 @@ public class LandingZoneApiControllerTest extends BaseSpringUnitTest {
         .andExpect(MockMvcResultMatchers.jsonPath("$.region", equalTo("southcentralus")));
   }
 
-  @Disabled("Flaky on date time comparisons")
   @Test
   void listAzureLandingZoneByBillingProfileIdSuccess() throws Exception {
-    var lzCreateDate = Instant.now().atOffset(ZoneOffset.UTC);
+    var lzCreateDate = LocalDateTime.parse("2024-05-03T15:09:56").atOffset(ZoneOffset.UTC);
     var landingZone =
         AzureLandingZoneFixtures.buildDefaultApiAzureLandingZone(
             LANDING_ZONE_ID,


### PR DESCRIPTION
This test was flaky and I disabled it to unblock a hotfix.  `Instant.now().atOffset(ZoneOffset.UTC).toString()` which we use for the assertion in this test can return a _slightly_ different result than the internal serialization mechanisms LZS uses when it renders the timestamp. Since we shouldn't use `now()` in tests anyway (that always leads to flakiness), I've opted to shift to a hardcoded date that consistently matches and re-enable the test. 