### PR TITLE
[ID-1266] Upgrade sam-client to latest

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation 'org.springframework:spring-aop'
     implementation 'org.springframework:spring-aspects'
     //we need to expose it at service module for status checking capability
-    api 'org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-6d19a41'
+    api 'org.broadinstitute.dsde.workbench:sam-client-javax_2.13:v0.0.226-1f1e893-SNAP'
     implementation 'bio.terra:billing-profile-manager-client:0.1.484-SNAPSHOT'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api'
     implementation group: 'com.azure', name: 'azure-core', version: '1.49.0'

--- a/library/src/main/java/bio/terra/landingzone/service/iam/LandingZoneSamClient.java
+++ b/library/src/main/java/bio/terra/landingzone/service/iam/LandingZoneSamClient.java
@@ -34,7 +34,7 @@ public class LandingZoneSamClient {
 
   private ApiClient getApiClient(String accessToken) {
     ApiClient apiClient = getApiClient();
-    apiClient.setAccessToken(accessToken);
+    apiClient.setBearerToken(accessToken);
     return apiClient;
   }
 

--- a/library/src/main/java/bio/terra/landingzone/service/iam/LandingZoneSamService.java
+++ b/library/src/main/java/bio/terra/landingzone/service/iam/LandingZoneSamService.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.BooleanUtils;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
-import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyMembershipV2;
+import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyMembershipRequest;
 import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
 import org.broadinstitute.dsde.workbench.client.sam.model.FullyQualifiedResourceId;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserResourcesResponse;
@@ -104,16 +104,16 @@ public class LandingZoneSamService {
             .resourceId(billingProfileId.toString())
             .resourceTypeName(SamConstants.SamResourceType.SPEND_PROFILE);
 
-    Map<String, AccessPolicyMembershipV2> policies = new HashMap<>();
+    Map<String, AccessPolicyMembershipRequest> policies = new HashMap<>();
     policies.put(
         "owner",
-        new AccessPolicyMembershipV2()
+        new AccessPolicyMembershipRequest()
             .addMemberEmailsItem(userInfo.getUserEmail())
             .addRolesItem(SamConstants.SamRole.OWNER));
     if (CollectionUtils.isNotEmpty(samClient.getLandingZoneResourceUsers())) {
       policies.put(
           "user",
-          new AccessPolicyMembershipV2()
+          new AccessPolicyMembershipRequest()
               .memberEmails(samClient.getLandingZoneResourceUsers())
               .addRolesItem(SamConstants.SamRole.USER));
     }

--- a/library/src/test/java/bio/terra/landingzone/service/iam/LandingZoneSamServiceTest.java
+++ b/library/src/test/java/bio/terra/landingzone/service/iam/LandingZoneSamServiceTest.java
@@ -24,7 +24,7 @@ import org.apache.http.HttpStatus;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
-import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyMembershipV2;
+import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyMembershipRequest;
 import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
 import org.broadinstitute.dsde.workbench.client.sam.model.FullyQualifiedResourceId;
 import org.broadinstitute.dsde.workbench.client.sam.model.RolesAndActions;
@@ -150,15 +150,15 @@ class LandingZoneSamServiceTest {
   @Test
   void createLandingZone_success() throws ApiException, InterruptedException {
     var listOfUsers = List.of(SAM_USER.getEmail());
-    Map<String, AccessPolicyMembershipV2> policies = new HashMap<>();
+    Map<String, AccessPolicyMembershipRequest> policies = new HashMap<>();
     policies.put(
         "owner",
-        new AccessPolicyMembershipV2()
+        new AccessPolicyMembershipRequest()
             .addMemberEmailsItem(SAM_USER.getEmail())
             .addRolesItem(SamConstants.SamRole.OWNER));
     policies.put(
         "user",
-        new AccessPolicyMembershipV2()
+        new AccessPolicyMembershipRequest()
             .memberEmails(listOfUsers)
             .addRolesItem(SamConstants.SamRole.USER));
     // Setup Mocks
@@ -176,10 +176,10 @@ class LandingZoneSamServiceTest {
   @Test
   void createLandingZone_noUsersInConfig() throws ApiException, InterruptedException {
     var listOfUsers = Collections.EMPTY_LIST;
-    Map<String, AccessPolicyMembershipV2> policies = new HashMap<>();
+    Map<String, AccessPolicyMembershipRequest> policies = new HashMap<>();
     policies.put(
         "owner",
-        new AccessPolicyMembershipV2()
+        new AccessPolicyMembershipRequest()
             .addMemberEmailsItem(SAM_USER.getEmail())
             .addRolesItem(SamConstants.SamRole.OWNER));
     // Setup Mocks
@@ -351,7 +351,7 @@ class LandingZoneSamServiceTest {
                 .enabled(enabled));
   }
 
-  private void verifyCreateResourceV2(Map<String, AccessPolicyMembershipV2> policies)
+  private void verifyCreateResourceV2(Map<String, AccessPolicyMembershipRequest> policies)
       throws ApiException {
     verify(resourcesApi)
         .createResourceV2(


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1266

Related PR: https://github.com/DataBiosphere/terra-workspace-manager/pull/1724

I'm updating WSM to the latest sam-client (for the new action managed identities API); but because of amalgamation I also need to update LZ-service (since the LZ-library pulls in the Sam client). 