### PR TITLE
WOR-1658 Workflows app will not start when the de-amalgamated LZS is enabled

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -109,6 +109,9 @@ landingzone:
       uaenorth:
         AKS_MACHINE_TYPE: "Standard_D4as_v5"
         POSTGRES_SERVER_SKU: "Standard_D2ds_v5"
+      australiaeast:
+        AKS_MACHINE_TYPE: "Standard_D4as_v5"
+        POSTGRES_SERVER_SKU: "Standard_D2ds_v5"
   sentry:
     dsn: ${env.sentry.dsn}
     environment: ${env.sentry.environment}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -89,6 +89,26 @@ landingzone:
       - SentinelHealth
       - StorageBlobLogs
       - Syslog
+  regions:
+    default-parameters:
+      eastus:
+        AKS_MACHINE_TYPE: "Standard_D4as_v5"
+        POSTGRES_SERVER_SKU: "Standard_D2ds_v5"
+      southcentralus:
+        AKS_MACHINE_TYPE: "Standard_D4as_v4"
+        POSTGRES_SERVER_SKU: "Standard_D2ds_v4"
+      centralus:
+        AKS_MACHINE_TYPE: "Standard_D4as_v4"
+        POSTGRES_SERVER_SKU: "Standard_D2ds_v4"
+      westus2:
+        AKS_MACHINE_TYPE: "Standard_D4as_v5"
+        POSTGRES_SERVER_SKU: "Standard_D2ds_v4"
+      southafricanorth:
+        AKS_MACHINE_TYPE: "Standard_D4as_v4"
+        POSTGRES_SERVER_SKU: "Standard_D2ds_v5"
+      uaenorth:
+        AKS_MACHINE_TYPE: "Standard_D4as_v5"
+        POSTGRES_SERVER_SKU: "Standard_D2ds_v5"
   sentry:
     dsn: ${env.sentry.dsn}
     environment: ${env.sentry.environment}


### PR DESCRIPTION
Jira [ticket](https://broadworkbench.atlassian.net/browse/WOR-1658)

Landing zone required configuration was missing. As a result landing zone falls back to the default value for node pool VM size which is 'Standard_A2_v2 ' instead of 'Standard_D4as_v5'. As a result, the relay listener application was struggling to start and preventing WDS/WORKFLOW application to respond.