### PR TITLE
[WIP] WOR-1662 [LZ Pentest] User input for billingProfileId is not validated for get LZ endpoint.

### DIFF
--- a/service/src/main/java/bio/terra/lz/futureservice/app/controller/LandingZoneApiController.java
+++ b/service/src/main/java/bio/terra/lz/futureservice/app/controller/LandingZoneApiController.java
@@ -66,15 +66,19 @@ public class LandingZoneApiController implements LandingZonesApi {
   @Override
   public ResponseEntity<ApiAzureLandingZoneList> listAzureLandingZones(UUID billingProfileId) {
     /*
-    Sometimes billingProfileId parameter can be null here even if original query parameter of the
-    GET request contains some value for it. This might happen during Tomcat server request parameter validation,
-    even before validation for type (UUID) of the parameter. Query string parameter's value can be sanitized
-    in case it contains forbidden characters.
-    We need to differentiate when parameter was supplied and sanitized and when it wasn't initially provided.
+    In certain cases, the billingProfileId parameter may be null, even if the original query parameter
+    of the GET request contains a value for it. This situation can arise during Tomcat server request
+    parameter validation, even before validating the type (UUID) of the parameter. For instance,
+    the query string parameter’s value might be sanitized if it contains forbidden characters.
+    It is important to distinguish between scenarios where the parameter was initially supplied
+    and when it was subsequently sanitized.
+
+    Example: Following value '%7bbase%7d%22%20or%20version()%20like%20%user' will be sanitized and
+    current method will receive null.
      */
     if (RequestQueryParamUtils.isBillingProfileIdSanitized(
         billingProfileId, request.getQueryString())) {
-      throw new BadRequestException("billing profile id is not valid!");
+      throw new BadRequestException("Value of the billingProfileId parameter is not valid.");
     }
 
     ApiAzureLandingZoneList result =

--- a/service/src/main/java/bio/terra/lz/futureservice/common/utils/RequestQueryParamUtils.java
+++ b/service/src/main/java/bio/terra/lz/futureservice/common/utils/RequestQueryParamUtils.java
@@ -6,13 +6,12 @@ import org.apache.commons.lang3.StringUtils;
 public class RequestQueryParamUtils {
   private RequestQueryParamUtils() {}
 
-  public static boolean isBillingProfileIdSanitized(UUID value, String originalRequestValue) {
-    String[] queryParam = originalRequestValue.split("=");
-    if (value != null || queryParam.length < 2) {
-      // it seems the value of the parameter wasn't initially supplied,
-      // hence the query parameter's value wasn't sanitized.
-      return false;
-    }
-    return !StringUtils.isEmpty(queryParam[1]); // value is null here;
+  public static boolean isBillingProfileIdSanitized(
+      UUID billingProfileId, String queryParamKeyPair) {
+    if (queryParamKeyPair == null) return false;
+    String[] billingProfileIdQueryParam = queryParamKeyPair.split("=");
+    String billingProfileIdQueryValue =
+        billingProfileIdQueryParam.length == 2 ? billingProfileIdQueryParam[1] : null;
+    return (billingProfileId == null) && !StringUtils.isEmpty(billingProfileIdQueryValue);
   }
 }

--- a/service/src/main/java/bio/terra/lz/futureservice/common/utils/RequestQueryParamUtils.java
+++ b/service/src/main/java/bio/terra/lz/futureservice/common/utils/RequestQueryParamUtils.java
@@ -12,6 +12,7 @@ public class RequestQueryParamUtils {
 
   public static boolean isBillingProfileIdSanitized(
       UUID billingProfileId, String requestQueryParamPairs) {
+    if (billingProfileId != null) return false;
     if (requestQueryParamPairs == null) return false;
 
     // unlikely, but we might have more than 1 parameter provided;
@@ -27,6 +28,7 @@ public class RequestQueryParamUtils {
     String[] billingProfileIdKeyValuePair = billingProfileIdQueryParamPair.get().split("=");
     String billingProfileIdQueryValue =
         billingProfileIdKeyValuePair.length == 2 ? billingProfileIdKeyValuePair[1] : null;
-    return (billingProfileId == null) && !StringUtils.isEmpty(billingProfileIdQueryValue);
+    // if we are here billingProfileId is null
+    return !StringUtils.isEmpty(billingProfileIdQueryValue);
   }
 }

--- a/service/src/main/java/bio/terra/lz/futureservice/common/utils/RequestQueryParamUtils.java
+++ b/service/src/main/java/bio/terra/lz/futureservice/common/utils/RequestQueryParamUtils.java
@@ -1,17 +1,32 @@
 package bio.terra.lz.futureservice.common.utils;
 
+import java.util.Arrays;
+import java.util.Optional;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 
 public class RequestQueryParamUtils {
+  private static final String BILLING_PROFILE_ID_PARAM_NAME = "billingProfileId";
+
   private RequestQueryParamUtils() {}
 
   public static boolean isBillingProfileIdSanitized(
-      UUID billingProfileId, String queryParamKeyPair) {
-    if (queryParamKeyPair == null) return false;
-    String[] billingProfileIdQueryParam = queryParamKeyPair.split("=");
+      UUID billingProfileId, String requestQueryParamPairs) {
+    if (requestQueryParamPairs == null) return false;
+
+    // unlikely, but we might have more than 1 parameter provided;
+    // billingProfileId=test&param1=value1
+    String[] allQueryParamsPairs = requestQueryParamPairs.split("&");
+    Optional<String> billingProfileIdQueryParamPair =
+        Arrays.stream(allQueryParamsPairs)
+            .filter(pairs -> pairs.contains(BILLING_PROFILE_ID_PARAM_NAME))
+            .findFirst();
+
+    if (billingProfileIdQueryParamPair.isEmpty()) return false;
+
+    String[] billingProfileIdKeyValuePair = billingProfileIdQueryParamPair.get().split("=");
     String billingProfileIdQueryValue =
-        billingProfileIdQueryParam.length == 2 ? billingProfileIdQueryParam[1] : null;
+        billingProfileIdKeyValuePair.length == 2 ? billingProfileIdKeyValuePair[1] : null;
     return (billingProfileId == null) && !StringUtils.isEmpty(billingProfileIdQueryValue);
   }
 }

--- a/service/src/main/java/bio/terra/lz/futureservice/common/utils/RequestQueryParamUtils.java
+++ b/service/src/main/java/bio/terra/lz/futureservice/common/utils/RequestQueryParamUtils.java
@@ -1,0 +1,18 @@
+package bio.terra.lz.futureservice.common.utils;
+
+import java.util.UUID;
+import org.apache.commons.lang3.StringUtils;
+
+public class RequestQueryParamUtils {
+  private RequestQueryParamUtils() {}
+
+  public static boolean isBillingProfileIdSanitized(UUID value, String originalRequestValue) {
+    String[] queryParam = originalRequestValue.split("=");
+    if (value != null || queryParam.length < 2) {
+      // it seems the value of the parameter wasn't initially supplied,
+      // hence the query parameter's value wasn't sanitized.
+      return false;
+    }
+    return !StringUtils.isEmpty(queryParam[1]); // value is null here;
+  }
+}

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -70,6 +70,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AzureLandingZoneList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '409':
           $ref: '#/components/responses/Conflict'
         '500':

--- a/service/src/test/java/bio/terra/lz/futureservice/common/utils/RequestQueryParamUtilsTest.java
+++ b/service/src/test/java/bio/terra/lz/futureservice/common/utils/RequestQueryParamUtilsTest.java
@@ -1,0 +1,51 @@
+package bio.terra.lz.futureservice.common.utils;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class RequestQueryParamUtilsTest {
+  private final String billingProfileIdQueryParam = "billingProfileId=%s";
+  private final String billingProfileIdAndOtherQueryParam = "billingProfileId=%s&param1=value1";
+  private final UUID billingProfileId = UUID.randomUUID();
+
+  @Test
+  void testWhenOriginalValueProvided() {
+    assertFalse(
+        RequestQueryParamUtils.isBillingProfileIdSanitized(
+            billingProfileId, billingProfileIdQueryParam.formatted(billingProfileId)));
+  }
+
+  @Test
+  void testWhenOriginalValueNotProvided() {
+    // original value is not provided, but the request contains corresponding query parameter.
+    assertTrue(
+        RequestQueryParamUtils.isBillingProfileIdSanitized(
+            null, billingProfileIdQueryParam.formatted("valueToBeSanitized")));
+  }
+
+  @Test
+  void testWhenOriginalValueNotProvided_AndMultipleQueryParamsProvided() {
+    // this is unlikely situation, but we might have some additional parameters provided
+    // (intentionally or not) together with billingProfileId;
+    // currently we support billingProfileId only
+    assertTrue(
+        RequestQueryParamUtils.isBillingProfileIdSanitized(
+            null, billingProfileIdAndOtherQueryParam.formatted("valueToBeSanitized")));
+  }
+
+  @Test
+  void testWhenOriginalValueNotProvided_MultipleQueryParamsProvidedWithoutBillingProfileId() {
+    // this is unlikely situation, but we might have some parameters provided
+    // (intentionally or not) without billingProfileId
+    assertFalse(
+        RequestQueryParamUtils.isBillingProfileIdSanitized(null, "param1=value1&param2=value2"));
+  }
+
+  @Test
+  void testWhenRequestDoesntHaveQueryParam() {
+    assertFalse(RequestQueryParamUtils.isBillingProfileIdSanitized(null, null));
+  }
+}


### PR DESCRIPTION
Regular validation works. For instance, in case instead of UUID some other string provided like "abs". But...

In certain cases, the "billingProfileId" parameter may be null, even if the original query parameter of the GET request contains a value for it. This situation can arise during Tomcat server request parameter validation, even before validating the type (UUID) of the parameter. For instance, the query string parameter’s value might be sanitized if it contains forbidden characters. It is important to distinguish between scenarios where the parameter was initially supplied and when it was subsequently sanitized.