### PR TITLE
WOR-1663 [LZ Pentest] Endpoints should return caching directives.

### DIFF
--- a/service/src/main/java/bio/terra/lz/futureservice/app/common/http/filter/CacheControlResponseHeaderFilter.java
+++ b/service/src/main/java/bio/terra/lz/futureservice/app/common/http/filter/CacheControlResponseHeaderFilter.java
@@ -1,0 +1,21 @@
+package bio.terra.lz.futureservice.app.common.http.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class CacheControlResponseHeaderFilter extends OncePerRequestFilter {
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    response.setHeader("Cache-Control", "no-store");
+    response.setHeader("Pragma", "no-cache");
+    filterChain.doFilter(request, response);
+  }
+}

--- a/service/src/test/java/bio/terra/lz/futureservice/app/controller/ControllerResponseHeaderTest.java
+++ b/service/src/test/java/bio/terra/lz/futureservice/app/controller/ControllerResponseHeaderTest.java
@@ -1,0 +1,33 @@
+package bio.terra.lz.futureservice.app.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import bio.terra.lz.futureservice.common.TestEndpoints;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+
+@SpringBootTest(
+    webEnvironment = RANDOM_PORT,
+    properties = {
+      // Disable instrumentation for spring-webmvc because pact still uses javax libs which causes
+      // opentelemetry to try to load the same bean name twice, once for javax and once for jakarta
+      "otel.instrumentation.spring-webmvc.enabled=false"
+    })
+public class ControllerResponseHeaderTest {
+
+  @Autowired TestRestTemplate restTemplate;
+
+  @Test
+  void listAzureLandingZoneDefinitions_ResponseContainsCacheControlHeaders() {
+    ResponseEntity<String> response =
+        restTemplate.getForEntity(
+            TestEndpoints.LIST_AZURE_LANDING_ZONES_DEFINITIONS_PATH, String.class);
+
+    assertEquals("no-store", response.getHeaders().getCacheControl());
+    assertEquals("no-cache", response.getHeaders().getPragma());
+  }
+}

--- a/service/src/test/java/bio/terra/lz/futureservice/app/controller/LandingZoneApiControllerTest.java
+++ b/service/src/test/java/bio/terra/lz/futureservice/app/controller/LandingZoneApiControllerTest.java
@@ -1,5 +1,8 @@
 package bio.terra.lz.futureservice.app.controller;
 
+import static bio.terra.lz.futureservice.common.TestEndpoints.AZURE_LANDING_ZONE_PATH;
+import static bio.terra.lz.futureservice.common.TestEndpoints.GET_CREATE_AZURE_LANDING_ZONE_RESULT;
+import static bio.terra.lz.futureservice.common.TestEndpoints.LIST_AZURE_LANDING_ZONES_DEFINITIONS_PATH;
 import static bio.terra.lz.futureservice.common.utils.MockMvcUtils.USER_REQUEST;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -52,11 +55,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 @AutoConfigureMockMvc
 public class LandingZoneApiControllerTest extends BaseSpringUnitTest {
-  private static final String AZURE_LANDING_ZONE_PATH = "/api/landingzones/v1/azure";
-  private static final String GET_CREATE_AZURE_LANDING_ZONE_RESULT =
-      "/api/landingzones/v1/azure/create-result";
-  private static final String LIST_AZURE_LANDING_ZONES_DEFINITIONS_PATH =
-      "/api/landingzones/definitions/v1/azure";
   private static final String JOB_ID = "newJobId";
   private static final UUID LANDING_ZONE_ID = UUID.randomUUID();
   private static final UUID BILLING_PROFILE_ID = UUID.randomUUID();

--- a/service/src/test/java/bio/terra/lz/futureservice/common/TestEndpoints.java
+++ b/service/src/test/java/bio/terra/lz/futureservice/common/TestEndpoints.java
@@ -1,0 +1,11 @@
+package bio.terra.lz.futureservice.common;
+
+public class TestEndpoints {
+  private TestEndpoints() {}
+
+  public static final String AZURE_LANDING_ZONE_PATH = "/api/landingzones/v1/azure";
+  public static final String GET_CREATE_AZURE_LANDING_ZONE_RESULT =
+      "/api/landingzones/v1/azure/create-result";
+  public static final String LIST_AZURE_LANDING_ZONES_DEFINITIONS_PATH =
+      "/api/landingzones/definitions/v1/azure";
+}


### PR DESCRIPTION
Now API response returns following caching directives:
-Cache-control: no-store
-Pragma: no-cache