### PR TITLE
WOR-1765 check spend-profile.read_job_result for lz create/delete jobs

### DIFF
--- a/library/src/main/java/bio/terra/landingzone/service/iam/SamConstants.java
+++ b/library/src/main/java/bio/terra/landingzone/service/iam/SamConstants.java
@@ -18,6 +18,7 @@ public class SamConstants {
 
   public static class SamSpendProfileAction {
     public static final String LINK = "link";
+    public static final String READ_JOB_RESULT = "read_job_result";
 
     private SamSpendProfileAction() {}
   }

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/LandingZoneFlightMapKeys.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/LandingZoneFlightMapKeys.java
@@ -6,6 +6,7 @@ public class LandingZoneFlightMapKeys {
   public static final String LANDING_ZONE_CREATE_PARAMS = "landingZoneCreateParams";
   public static final String BEARER_TOKEN = "bearerToken";
   public static final String BILLING_PROFILE = "billingProfile";
+  public static final String BILLING_PROFILE_ID = "billingProfileId";
   public static final String ATTACH = "attach";
   public static final String STORAGE_ACCOUNT_NAME = "storageAccountName";
   public static final String CREATE_LANDING_ZONE_PARAMETERS_RESOLVER = "parametersResolver";

--- a/library/src/test/java/bio/terra/landingzone/service/landingzone/azure/LandingZoneServiceTest.java
+++ b/library/src/test/java/bio/terra/landingzone/service/landingzone/azure/LandingZoneServiceTest.java
@@ -145,7 +145,7 @@ public class LandingZoneServiceTest {
     verify(landingZoneJobService, times(1))
         .retrieveAsyncJobResult(jobIdCaptor.capture(), classCaptor.capture());
     verify(landingZoneJobService, times(1))
-        .verifyUserAccessForDeleteJobResult(bearerToken, landingZoneId, jobId);
+        .verifyUserAccess(bearerToken, jobId, Optional.of(landingZoneId));
 
     assertEquals(jobId, jobIdCaptor.getValue());
     assertEquals(DeletedLandingZone.class, classCaptor.getValue());
@@ -160,7 +160,7 @@ public class LandingZoneServiceTest {
     verify(landingZoneJobService, times(1))
         .retrieveAsyncJobResult(jobIdCaptor.capture(), classCaptor.capture());
     verify(landingZoneJobService, times(1))
-        .verifyUserAccessForDeleteJobResult(bearerToken, landingZoneId, jobId);
+        .verifyUserAccess(bearerToken, jobId, Optional.of(landingZoneId));
 
     assertEquals(jobId, jobIdCaptor.getValue());
     assertEquals(DeletedLandingZone.class, classCaptor.getValue());

--- a/library/src/test/java/bio/terra/landingzone/service/landingzone/azure/LandingZoneServiceTest.java
+++ b/library/src/test/java/bio/terra/landingzone/service/landingzone/azure/LandingZoneServiceTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -55,6 +54,7 @@ import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneRequest;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResourcesByPurpose;
 import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.profile.model.ProfileModel;
 import com.azure.core.management.Region;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -112,6 +112,7 @@ public class LandingZoneServiceTest {
   @Mock private LandingZoneBillingProfileManagerService bpmService;
   @Mock private LandingZoneTestingConfiguration testingConfiguration;
   @Captor ArgumentCaptor<UUID> captorLandingZoneId;
+  @Captor ArgumentCaptor<UUID> captorBillingProfileId;
 
   @BeforeEach
   void setup() {
@@ -172,6 +173,14 @@ public class LandingZoneServiceTest {
     when(mockJobBuilder.landingZoneRequest(any())).thenReturn(mockJobBuilder);
     when(mockJobBuilder.addParameter(any(), any())).thenReturn(mockJobBuilder);
     when(landingZoneJobService.newJob()).thenReturn(mockJobBuilder);
+    when(bpmService.getBillingProfile(bearerToken, billingProfileId))
+        .thenReturn(new ProfileModel().id(billingProfileId));
+    when(mockJobBuilder.addParameter(
+            eq(LandingZoneFlightMapKeys.BILLING_PROFILE_ID), captorBillingProfileId.capture()))
+        .thenReturn(mockJobBuilder);
+    when(mockJobBuilder.addParameter(
+            eq(LandingZoneFlightMapKeys.LANDING_ZONE_ID), captorLandingZoneId.capture()))
+        .thenReturn(mockJobBuilder);
 
     LandingZoneRequest landingZoneRequest =
         LandingZoneRequest.builder()
@@ -184,10 +193,8 @@ public class LandingZoneServiceTest {
     landingZoneService.startLandingZoneCreationJob(
         bearerToken, "newJobId", landingZoneRequest, "create-result");
 
-    verify(mockJobBuilder, times(1))
-        .addParameter(eq(LandingZoneFlightMapKeys.LANDING_ZONE_ID), captorLandingZoneId.capture());
-    assertNotEquals(landingZoneId, captorLandingZoneId.getValue());
-    verify(landingZoneJobService, times(1)).newJob();
+    assertNotNull(captorLandingZoneId.getValue());
+    assertEquals(billingProfileId, captorBillingProfileId.getValue());
     verify(mockJobBuilder, times(1)).submit();
   }
 
@@ -197,6 +204,14 @@ public class LandingZoneServiceTest {
     when(mockJobBuilder.landingZoneRequest(any())).thenReturn(mockJobBuilder);
     when(mockJobBuilder.addParameter(any(), any())).thenReturn(mockJobBuilder);
     when(landingZoneJobService.newJob()).thenReturn(mockJobBuilder);
+    when(bpmService.getBillingProfile(bearerToken, billingProfileId))
+        .thenReturn(new ProfileModel().id(billingProfileId));
+    when(mockJobBuilder.addParameter(
+            eq(LandingZoneFlightMapKeys.BILLING_PROFILE_ID), captorBillingProfileId.capture()))
+        .thenReturn(mockJobBuilder);
+    when(mockJobBuilder.addParameter(
+            eq(LandingZoneFlightMapKeys.LANDING_ZONE_ID), captorLandingZoneId.capture()))
+        .thenReturn(mockJobBuilder);
 
     LandingZoneRequest landingZoneRequest =
         LandingZoneRequest.builder()
@@ -210,9 +225,8 @@ public class LandingZoneServiceTest {
     landingZoneService.startLandingZoneCreationJob(
         bearerToken, "newJobId", landingZoneRequest, "create-result");
 
-    verify(mockJobBuilder, times(1))
-        .addParameter(eq(LandingZoneFlightMapKeys.LANDING_ZONE_ID), eq(landingZoneId));
-    verify(landingZoneJobService, times(1)).newJob();
+    assertEquals(billingProfileId, captorBillingProfileId.getValue());
+    assertEquals(landingZoneId, captorLandingZoneId.getValue());
     verify(mockJobBuilder, times(1)).submit();
   }
 
@@ -316,16 +330,22 @@ public class LandingZoneServiceTest {
     String resultPath = "delete-result";
 
     LandingZoneJobBuilder mockJobBuilder = createMockJobBuilder(OperationType.DELETE);
-    when(mockJobBuilder.addParameter(LandingZoneFlightMapKeys.LANDING_ZONE_ID, landingZoneId))
+    when(mockJobBuilder.addParameter(
+            eq(LandingZoneFlightMapKeys.LANDING_ZONE_ID), captorLandingZoneId.capture()))
         .thenReturn(mockJobBuilder);
     when(mockJobBuilder.addParameter(JobMapKeys.RESULT_PATH.getKeyName(), resultPath))
         .thenReturn(mockJobBuilder);
     when(landingZoneJobService.newJob()).thenReturn(mockJobBuilder);
+    when(landingZoneDao.getLandingZoneRecord(landingZoneId)).thenReturn(createLandingZoneRecord());
+    when(mockJobBuilder.addParameter(
+            eq(LandingZoneFlightMapKeys.BILLING_PROFILE_ID), captorBillingProfileId.capture()))
+        .thenReturn(mockJobBuilder);
 
     landingZoneService.startLandingZoneDeletionJob(
         bearerToken, "newJobId", landingZoneId, resultPath);
 
-    verify(landingZoneJobService, times(1)).newJob();
+    assertEquals(billingProfileId, captorBillingProfileId.getValue());
+    assertEquals(landingZoneId, captorLandingZoneId.getValue());
     verify(mockJobBuilder, times(1)).submit();
   }
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1765

This PR simplifies and consolidates the permission check for create and delete landing zone jobs. There are 2 subtle changes I want to call out
1. The permission check always throws forbidden, never not found, to prevent information leaks. A related fixed leak would output the billing profile id of a job if the user did not have access
2. Create/delete jobs need the billing profile id as an input parameter which will break any jobs in flight. To avoid that I can release a PR ahead of time that starts populating the input parameter. But I want thumbs on this PR before deciding the best approach for roll out.