### PR TITLE
[WOR-1448] Remove org.liquibase.gradle dependency

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,7 +5,6 @@ plugins {
     id 'com.srcclr.gradle'
     id 'org.sonarqube'
     id 'com.jfrog.artifactory'
-    id 'org.liquibase.gradle' version '3.0.0'
 }
 
 apply from: 'publishing.gradle'
@@ -98,17 +97,5 @@ sonarqube {
         property 'sonar.projectKey', 'DataBiosphere_terra-landing-zone-service'
         property 'sonar.organization', 'broad-databiosphere'
         property 'sonar.host.url', 'https://sonarcloud.io'
-    }
-}
-
-liquibase {
-    activities {
-        catalog {
-            changeLogFile 'src/main/resources/db/changelog.xml'
-            url 'jdbc:postgresql://localhost:5432/landingzone_db'
-            username 'dbuser'
-            password 'dbpwd'
-            logLevel 'info'
-        }
     }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'com.srcclr.gradle'
     id 'org.sonarqube'
     id 'com.jfrog.artifactory'
-    id 'org.liquibase.gradle' version '2.2.2'
+    id 'org.liquibase.gradle' version '3.0.0'
 }
 
 apply from: 'publishing.gradle'


### PR DESCRIPTION
Ticket: [WOR-1448](https://broadworkbench.atlassian.net/browse/WOR-1448)
* https://github.com/DataBiosphere/terra-landing-zone-service/pull/490 tried to update the liquibase gradle plugin dependency to 3.0.0 but caused build failures. Upon investigation, we do not appear to be using this plugin at all as LZS uses TCL's [LiquibaseMigrator](https://github.com/DataBiosphere/terra-common-lib/blob/db8a959c2b6185755ed48917e9951c97f8691d8e/src/main/java/bio/terra/common/migrate/LiquibaseMigrator.java) to migrate its database when it starts up ([source](https://github.com/DataBiosphere/terra-landing-zone-service/blob/860cdf1814413c8ba53d76ea32ba47530506f3a0/library/src/main/java/bio/terra/landingzone/library/LandingZoneMain.java#L20-L24)) similar to our other services ([BPM](https://github.com/DataBiosphere/terra-billing-profile-manager/blob/fe5133e2b2da8a75a904e5d7f813d1915587df04/service/src/main/java/bio/terra/profile/app/StartupInitializer.java#L27-L32), [WSM](https://github.com/DataBiosphere/terra-workspace-manager/blob/903d525c938d2b3f43c86521415451012271a886/service/src/main/java/bio/terra/workspace/app/StartupInitializer.java#L35-L41)). This PR removes it.

[WOR-1448]: https://broadworkbench.atlassian.net/browse/WOR-1448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ