### PR TITLE
[WOR-1807] Change default AKS machine type in south central US

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -95,7 +95,7 @@ landingzone:
         AKS_MACHINE_TYPE: "Standard_D4as_v5"
         POSTGRES_SERVER_SKU: "Standard_D2ds_v5"
       southcentralus:
-        AKS_MACHINE_TYPE: "Standard_D4as_v4"
+        AKS_MACHINE_TYPE: "Standard_D4s_v3"
         POSTGRES_SERVER_SKU: "Standard_D2ds_v4"
       centralus:
         AKS_MACHINE_TYPE: "Standard_D4as_v4"

--- a/service/src/test/java/bio/terra/lz/futureservice/app/controller/LandingZoneApiControllerTest.java
+++ b/service/src/test/java/bio/terra/lz/futureservice/app/controller/LandingZoneApiControllerTest.java
@@ -349,6 +349,7 @@ public class LandingZoneApiControllerTest extends BaseSpringUnitTest {
         .andExpect(MockMvcResultMatchers.jsonPath("$.region", equalTo("southcentralus")));
   }
 
+  // TESTING
   @Test
   void listAzureLandingZoneByBillingProfileIdSuccess() throws Exception {
     var lzCreateDate = LocalDateTime.parse("2024-05-03T15:09:56").atOffset(ZoneOffset.UTC);


### PR DESCRIPTION
Standard_D4as_v4 is not allocating in scus,  Standard_D4s_v3 works in my testing. 