### PR TITLE
[TOAZ-369] Referenced LZ definition

### DIFF
--- a/library/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/LandingZoneStepsDefinitionProviderFactory.java
+++ b/library/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/LandingZoneStepsDefinitionProviderFactory.java
@@ -8,6 +8,8 @@ public class LandingZoneStepsDefinitionProviderFactory {
       case CROMWELL_BASE_DEFINITION_STEPS_PROVIDER_TYPE -> new CromwellStepsDefinitionProvider();
       case PROTECTED_DATA_DEFINITION_STEPS_PROVIDER_NAME ->
           new ProtectedDataStepsDefinitionProvider();
+      case REFERENCED_DEFINITION_STEPS_PROVIDER_TYPE ->
+          new ReferencedLandingZoneStepsDefinitionProvider();
     };
   }
 }

--- a/library/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/ReferencedLandingZoneStepsDefinitionProvider.java
+++ b/library/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/ReferencedLandingZoneStepsDefinitionProvider.java
@@ -18,7 +18,7 @@ import org.apache.commons.lang3.tuple.Pair;
 public class ReferencedLandingZoneStepsDefinitionProvider implements StepsDefinitionProvider {
   private static final String LZ_NAME = "Referenced Landing Zone";
   private static final String LZ_DESC =
-      "Enlist existing sources in a Landing Zone. Expected resources: VNet, AKS, Batch Account,"
+      "Referenced landing zones utilize existing resources. These resources should be available and deployed in the managed resource group. Expected resources include: VNet, AKS, Batch Account,"
           + " Storage Account, PostgreSQL server, Subnets for AKS, Batch, Postgresql, and Compute";
 
   @Override

--- a/library/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/ReferencedLandingZoneStepsDefinitionProvider.java
+++ b/library/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/ReferencedLandingZoneStepsDefinitionProvider.java
@@ -1,0 +1,60 @@
+package bio.terra.landingzone.library.landingzones.definition.factories;
+
+import bio.terra.landingzone.common.utils.RetryRules;
+import bio.terra.landingzone.library.configuration.LandingZoneProtectedDataConfiguration;
+import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
+import bio.terra.landingzone.library.landingzones.definition.DefinitionHeader;
+import bio.terra.landingzone.library.landingzones.definition.DefinitionVersion;
+import bio.terra.landingzone.library.landingzones.definition.factories.validation.InputParametersValidationFactory;
+import bio.terra.landingzone.stairway.flight.ParametersResolverProvider;
+import bio.terra.landingzone.stairway.flight.ResourceNameProvider;
+import bio.terra.landingzone.stairway.flight.create.reference.resource.step.*;
+import bio.terra.landingzone.stairway.flight.create.resource.step.*;
+import bio.terra.stairway.RetryRule;
+import bio.terra.stairway.Step;
+import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
+
+public class ReferencedLandingZoneStepsDefinitionProvider implements StepsDefinitionProvider {
+  private static final String LZ_NAME = "Referenced Landing Zone";
+  private static final String LZ_DESC =
+      "Enlist existing sources in a Landing Zone. Expected resources: VNet, AKS, Batch Account,"
+          + " Storage Account, PostgreSQL server, Subnets for AKS, Batch, Postgresql, and Compute";
+
+  @Override
+  public String landingZoneDefinition() {
+    return StepsDefinitionFactoryType.REFERENCED_DEFINITION_STEPS_PROVIDER_TYPE.getValue();
+  }
+
+  @Override
+  public DefinitionHeader header() {
+    return new DefinitionHeader(LZ_NAME, LZ_DESC);
+  }
+
+  @Override
+  public List<DefinitionVersion> availableVersions() {
+    return List.of(DefinitionVersion.V1);
+  }
+
+  @Override
+  public List<Pair<Step, RetryRule>> get(
+      ArmManagers armManagers,
+      ParametersResolverProvider parametersResolverProvider,
+      ResourceNameProvider resourceNameProvider,
+      LandingZoneProtectedDataConfiguration landingZoneProtectedDataConfiguration) {
+    return List.of(
+        Pair.of(new GetManagedResourceGroupInfo(armManagers), RetryRules.cloud()),
+        Pair.of(new GetParametersResolver(parametersResolverProvider), RetryRules.shortDatabase()),
+        Pair.of(
+            new ValidateLandingZoneParametersStep(
+                InputParametersValidationFactory.buildValidators(
+                    StepsDefinitionFactoryType.REFERENCED_DEFINITION_STEPS_PROVIDER_TYPE)),
+            RetryRules.shortExponential()),
+        Pair.of(new ReferencedVnetStep(armManagers), RetryRules.cloud()),
+        Pair.of(new ReferencedAksStep(armManagers), RetryRules.cloud()),
+        Pair.of(new ReferencedBatchStep(armManagers), RetryRules.cloud()),
+        Pair.of(new ReferencedStorageStep(armManagers), RetryRules.cloud()),
+        Pair.of(new ReferencedRelayNamespaceStep(armManagers), RetryRules.cloud()),
+        Pair.of(new ReferencedAppInsightsStep(armManagers), RetryRules.cloud()));
+  }
+}

--- a/library/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/StepsDefinitionFactoryType.java
+++ b/library/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/StepsDefinitionFactoryType.java
@@ -2,7 +2,8 @@ package bio.terra.landingzone.library.landingzones.definition.factories;
 
 public enum StepsDefinitionFactoryType {
   CROMWELL_BASE_DEFINITION_STEPS_PROVIDER_TYPE("CromwellBaseResourcesFactory"),
-  PROTECTED_DATA_DEFINITION_STEPS_PROVIDER_NAME("ProtectedDataResourcesFactory");
+  PROTECTED_DATA_DEFINITION_STEPS_PROVIDER_NAME("ProtectedDataResourcesFactory"),
+  REFERENCED_DEFINITION_STEPS_PROVIDER_TYPE("ReferencedResourcesFactory");
 
   private final String value;
 

--- a/library/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/validation/InputParametersValidationFactory.java
+++ b/library/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/validation/InputParametersValidationFactory.java
@@ -11,7 +11,12 @@ public class InputParametersValidationFactory {
       case CROMWELL_BASE_DEFINITION_STEPS_PROVIDER_TYPE -> buildCromwellLandingZoneValidators();
       case PROTECTED_DATA_DEFINITION_STEPS_PROVIDER_NAME ->
           buildProtectedDataLandingZoneValidators();
+      case REFERENCED_DEFINITION_STEPS_PROVIDER_TYPE -> buildReferencedLandingZoneValidators();
     };
+  }
+
+  private static List<InputParameterValidator> buildReferencedLandingZoneValidators() {
+    return List.of(new ReferencedVNetValidator());
   }
 
   private static List<InputParameterValidator> buildCromwellLandingZoneValidators() {

--- a/library/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/validation/ReferencedVNetValidator.java
+++ b/library/src/main/java/bio/terra/landingzone/library/landingzones/definition/factories/validation/ReferencedVNetValidator.java
@@ -1,0 +1,41 @@
+package bio.terra.landingzone.library.landingzones.definition.factories.validation;
+
+import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
+import bio.terra.landingzone.library.landingzones.definition.factories.exception.InvalidInputParameterException;
+import bio.terra.landingzone.stairway.flight.LandingZoneDefaultParameters;
+import org.apache.logging.log4j.util.Strings;
+
+public class ReferencedVNetValidator implements InputParameterValidator {
+
+  @Override
+  public void validate(ParametersResolver parametersResolver)
+      throws InvalidInputParameterException {
+    StringBuilder sbErrors = new StringBuilder();
+
+    validateRequiredParameter(
+        parametersResolver, LandingZoneDefaultParameters.ParametersNames.BATCH_SUBNET, sbErrors);
+    validateRequiredParameter(
+        parametersResolver, LandingZoneDefaultParameters.ParametersNames.COMPUTE_SUBNET, sbErrors);
+
+    var errorMessage = sbErrors.toString();
+    if (!Strings.isBlank(errorMessage)) {
+      throw new InvalidInputParameterException(errorMessage);
+    }
+  }
+
+  private void validateRequiredParameter(
+      ParametersResolver parametersResolver,
+      LandingZoneDefaultParameters.ParametersNames parameterName,
+      StringBuilder sbErrorMessage) {
+    String value = parametersResolver.getValue(parameterName.name());
+    if (Strings.isBlank(value)) {
+      sbErrorMessage.append(" ");
+      sbErrorMessage.append(buildMissingParameterErrorMessage(parameterName));
+    }
+  }
+
+  private String buildMissingParameterErrorMessage(
+      LandingZoneDefaultParameters.ParametersNames parameterName) {
+    return String.format("%s is required.", parameterName.name());
+  }
+}

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/LandingZoneDefaultParameters.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/LandingZoneDefaultParameters.java
@@ -48,7 +48,13 @@ public class LandingZoneDefaultParameters {
     AKS_COST_SAVING_SPOT_NODES_ENABLED,
     AKS_COST_SAVING_VPA_ENABLED,
     STORAGE_ACCOUNT_SKU_TYPE,
-    ENABLE_PGBOUNCER
+    ENABLE_PGBOUNCER,
+
+    // The following parameters are used for referenced VNets
+    POSTGRESQL_SUBNET,
+    COMPUTE_SUBNET,
+    BATCH_SUBNET,
+    AKS_NODE_POOL_SUBNET,
   }
 
   public static Map<String, String> get() {

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/LandingZoneDefaultParameters.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/LandingZoneDefaultParameters.java
@@ -51,10 +51,8 @@ public class LandingZoneDefaultParameters {
     ENABLE_PGBOUNCER,
 
     // The following parameters are used for referenced VNets
-    POSTGRESQL_SUBNET,
     COMPUTE_SUBNET,
     BATCH_SUBNET,
-    AKS_NODE_POOL_SUBNET,
   }
 
   public static Map<String, String> get() {

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ArmResourceType.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ArmResourceType.java
@@ -1,25 +1,25 @@
 package bio.terra.landingzone.stairway.flight.create.reference.resource.step;
 
 public enum ArmResourceType {
-    AKS("Microsoft.ContainerService/managedClusters"),
-    VNET("Microsoft.Network/virtualNetworks"),
-    STORAGE_ACCOUNT("Microsoft.Storage/storageAccounts"),
-    POSTGRES("Microsoft.DBforPostgreSQL/servers"),
-    BATCH("Microsoft.Batch/batchAccounts"),
-    APP_INSIGHTS("Microsoft.Insights/components");
+  AKS("Microsoft.ContainerService/managedClusters"),
+  VNET("Microsoft.Network/virtualNetworks"),
+  STORAGE_ACCOUNT("Microsoft.Storage/storageAccounts"),
+  POSTGRES("Microsoft.DBforPostgreSQL/servers"),
+  BATCH("Microsoft.Batch/batchAccounts"),
+  APP_INSIGHTS("Microsoft.Insights/components");
 
-    private final String value;
+  private final String value;
 
-    ArmResourceType(String value) {
-        this.value = value;
-    }
+  ArmResourceType(String value) {
+    this.value = value;
+  }
 
-    public String getValue() {
-        return value;
-    }
+  public String getValue() {
+    return value;
+  }
 
-    @Override
-    public String toString() {
-        return value;
-    }
+  @Override
+  public String toString() {
+    return value;
+  }
 }

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ArmResourceType.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ArmResourceType.java
@@ -6,7 +6,8 @@ public enum ArmResourceType {
   STORAGE_ACCOUNT("Microsoft.Storage/storageAccounts"),
   POSTGRES("Microsoft.DBforPostgreSQL/servers"),
   BATCH("Microsoft.Batch/batchAccounts"),
-  APP_INSIGHTS("Microsoft.Insights/components");
+  APP_INSIGHTS("Microsoft.Insights/components"),
+  RELAY_NAMESPACE("Microsoft.Relay/namespaces");
 
   private final String value;
 

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ArmResourceType.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ArmResourceType.java
@@ -1,0 +1,25 @@
+package bio.terra.landingzone.stairway.flight.create.reference.resource.step;
+
+public enum ArmResourceType {
+    AKS("Microsoft.ContainerService/managedClusters"),
+    VNET("Microsoft.Network/virtualNetworks"),
+    STORAGE_ACCOUNT("Microsoft.Storage/storageAccounts"),
+    POSTGRES("Microsoft.DBforPostgreSQL/servers"),
+    BATCH("Microsoft.Batch/batchAccounts"),
+    APP_INSIGHTS("Microsoft.Insights/components");
+
+    private final String value;
+
+    ArmResourceType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ArmResourceType.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ArmResourceType.java
@@ -4,7 +4,7 @@ public enum ArmResourceType {
   AKS("Microsoft.ContainerService/managedClusters"),
   VNET("Microsoft.Network/virtualNetworks"),
   STORAGE_ACCOUNT("Microsoft.Storage/storageAccounts"),
-  POSTGRES("Microsoft.DBforPostgreSQL/servers"),
+  POSTGRES_FLEXIBLE("Microsoft.DBforPostgreSQL/flexibleServers"),
   BATCH("Microsoft.Batch/batchAccounts"),
   APP_INSIGHTS("Microsoft.Insights/components"),
   RELAY_NAMESPACE("Microsoft.Relay/namespaces");

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/BaseReferencedResourceStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/BaseReferencedResourceStep.java
@@ -123,7 +123,6 @@ public abstract class BaseReferencedResourceStep implements Step {
     return tagsToApply;
   }
 
-  @NotNull
   private Map<String, String> getLzResourceTags(
       FlightContext context, GenericResource genericResource) {
 
@@ -154,9 +153,7 @@ public abstract class BaseReferencedResourceStep implements Step {
             .azureResourceManager()
             .genericResources()
             .listByResourceGroup(getMRGName(flightContext))) {
-      var fullResourceTypeFromResource =
-          String.format("%s/%s", resource.resourceProviderNamespace(), resource.resourceType());
-      if (fullResourceTypeFromResource.equalsIgnoreCase(getArmResourceType().toString())) {
+      if (resource.type().equalsIgnoreCase(getArmResourceType().toString())) {
         return Optional.of(resource);
       }
     }

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/BaseReferencedResourceStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/BaseReferencedResourceStep.java
@@ -1,0 +1,250 @@
+package bio.terra.landingzone.stairway.flight.create.reference.resource.step;
+
+import bio.terra.landingzone.common.utils.MetricUtils;
+import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
+import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
+import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
+import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
+import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneRequest;
+import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
+import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.create.resource.step.GetManagedResourceGroupInfo;
+import bio.terra.landingzone.stairway.flight.exception.translation.FlightExceptionTranslator;
+import bio.terra.landingzone.stairway.flight.exception.utils.ManagementExceptionUtils;
+import bio.terra.landingzone.stairway.flight.utils.FlightUtils;
+import bio.terra.stairway.*;
+import bio.terra.stairway.exception.RetryException;
+import com.azure.core.management.exception.ManagementException;
+import com.azure.resourcemanager.resources.models.GenericResource;
+import org.apache.commons.collections4.map.HashedMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static bio.terra.landingzone.stairway.flight.utils.FlightUtils.maybeThrowAzureInterruptedException;
+
+public abstract class BaseReferencedResourceStep implements Step {
+  private static final Logger logger = LoggerFactory.getLogger(BaseReferencedResourceStep.class);
+
+  protected static final String REFERENCED_RESOURCE_ID  = "referencedResourceId";
+
+  protected static final String FAILED_TO_CREATE_REF_RESOURCE =
+      "Failed to create landing zone {} referenced resource. landingZoneId={}. Error: {}";
+
+  protected static final String RESOURCE_CREATED =
+      "{} resource id='{}' in resource group '{}' successfully created.";
+  private static final String REFERENCED_RESOURCE_NOT_FOUND =
+      "{} doesn't exist.";
+  private static final String FAILED_ATTEMPT_TO_REMOVE_LZ_TAGS =
+      "Failed attempt to remove the landing zone tags for resource: {}. Id={}";
+
+    protected final ArmManagers armManagers;
+
+  protected BaseReferencedResourceStep(
+      ArmManagers armManagers) {
+    this.armManagers = armManagers;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+
+    var landingZoneId =
+        getParameterOrThrow(
+            context.getWorkingMap(),
+            LandingZoneFlightMapKeys.LANDING_ZONE_ID,
+            UUID.class);
+
+    var azureLandingZoneRequest =
+        getParameterOrThrow(
+            context.getInputParameters(),
+            LandingZoneFlightMapKeys.LANDING_ZONE_CREATE_PARAMS,
+            LandingZoneRequest.class);
+
+    try {
+      var stepDuration =
+          MetricUtils.configureTimerForLzStepDuration(
+              azureLandingZoneRequest.definition(), getArmResourceType().toString());
+      var start = Instant.now().toEpochMilli();
+
+      tagReferencedResourceAndSetContext(context);
+
+      var finish = Instant.now().toEpochMilli();
+      stepDuration.record(Duration.ofMillis(finish - start));
+    } catch (ManagementException e) {
+      return handleManagementException(
+          e,
+          landingZoneId.toString(),
+          azureLandingZoneRequest.definition());
+    } catch (RuntimeException e) {
+      MetricUtils.incrementLandingZoneCreationFailure(azureLandingZoneRequest.definition());
+      throw maybeThrowAzureInterruptedException(e);
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  private void tagReferencedResourceAndSetContext(FlightContext context) {
+    GenericResource resource = findReferencedResourceByArmResourceType(context)
+            .orElseThrow(()-> new RuntimeException(String.format("A resource of type:%s could not be found in resource group: %s", getArmResourceType(), getMRGName(context))));
+
+    setLandingZoneResourceTags(context, resource);
+
+    context.getWorkingMap().put(REFERENCED_RESOURCE_ID, resource.id());
+  }
+
+  private void setLandingZoneResourceTags(FlightContext context, GenericResource genericResource) {
+    var landingZoneId =
+            getParameterOrThrow(
+                    context.getWorkingMap(),
+                    LandingZoneFlightMapKeys.LANDING_ZONE_ID,
+                    UUID.class);
+
+    Map<String, String> resourceTags = getLandingZoneResourceTags(context, genericResource.id());
+
+    Map<String,String> tagsToApply = new HashedMap<>(resourceTags);
+
+    tagsToApply.put(LandingZoneTagKeys.LANDING_ZONE_ID.toString(),
+            landingZoneId.toString());
+
+    if (isSharedResource()){
+      tagsToApply.put(LandingZoneTagKeys.LANDING_ZONE_PURPOSE.toString(), ResourcePurpose.SHARED_RESOURCE.toString());
+    }
+
+    armManagers.azureResourceManager().tagOperations().updateTags(genericResource.id(), tagsToApply);
+  }
+
+  protected abstract boolean isSharedResource();
+
+  protected abstract Map<String,String> getLandingZoneResourceTags(FlightContext context, String resourceId);
+
+  private Optional<GenericResource> findReferencedResourceByArmResourceType(FlightContext flightContext){
+    for (GenericResource resource: armManagers.azureResourceManager().genericResources().listByResourceGroup(getMRGName(flightContext))){
+      if (resource.resourceType().equalsIgnoreCase(getArmResourceType().toString())){
+        return Optional.of(resource);
+      }
+    }
+    return Optional.empty();
+  }
+
+  protected Optional<StepResult> maybeHandleManagementException(ManagementException e) {
+    return Optional.empty();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
+    var resourceId = getResourceId(flightContext);
+    try {
+      if (resourceId.isPresent()) {
+
+        removeLandingZoneTags(flightContext, resourceId.get());
+
+        return StepResult.getStepResultSuccess();
+      }
+
+      //if the resource id is not set, that means that the referenced resource does not exist.
+      //There is no need to perform any rollback operation. Hence, we warn and return success.
+      logger.warn(REFERENCED_RESOURCE_NOT_FOUND, getArmResourceType());
+      return StepResult.getStepResultSuccess();
+    } catch (RuntimeException e) {
+      logger.error(FAILED_ATTEMPT_TO_REMOVE_LZ_TAGS, getArmResourceType(), resourceId.orElse("n/a"));
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
+    }
+
+  }
+
+  private void removeLandingZoneTags(FlightContext flightContext, String resourceId) {
+    //get tags for the resource.
+    Map<String,String> tags = armManagers.azureResourceManager().genericResources().getById(resourceId).tags();
+
+    //only attempt to remove the landing zone tags if they are assigned to the current LZ
+    if (containsCurrentLzId(tags, flightContext)){
+      //remove LZ id tag.
+      tags.remove(LandingZoneTagKeys.LANDING_ZONE_ID.toString());
+
+      //remove purpose tag.
+        if (isSharedResource()){
+            tags.remove(LandingZoneTagKeys.LANDING_ZONE_PURPOSE.toString());
+        }
+
+      //remove the tags that were added by reference resource, if present.
+      for (String key : getLandingZoneResourceTags(flightContext, resourceId).keySet()) {
+          tags.remove(key);
+      }
+
+      armManagers.azureResourceManager().tagOperations().updateTags(resourceId, tags);
+    }
+  }
+
+  private boolean containsCurrentLzId(Map<String, String> tags, FlightContext context) {
+    var landingZoneId =
+            getParameterOrThrow(
+                    context.getInputParameters(), LandingZoneFlightMapKeys.LANDING_ZONE_ID, UUID.class);
+
+    return tags.containsKey(LandingZoneTagKeys.LANDING_ZONE_ID.toString())
+            &&
+            tags.get(LandingZoneTagKeys.LANDING_ZONE_ID.toString()).equals(landingZoneId.toString());
+  }
+
+
+  protected abstract ArmResourceType getArmResourceType();
+
+  protected Optional<String> getResourceId(FlightContext context){
+    return Optional.ofNullable(context.getWorkingMap().get(REFERENCED_RESOURCE_ID, String.class));
+  }
+
+    protected <T> T getParameterOrThrow(FlightMap parameters, String name, Class<T> clazz) {
+    FlightUtils.validateRequiredEntries(parameters, name);
+    return parameters.get(name, clazz);
+  }
+
+  protected String getMRGName(FlightContext context) {
+    return getParameterOrThrow(
+            context.getWorkingMap(),
+            GetManagedResourceGroupInfo.TARGET_MRG_KEY,
+            TargetManagedResourceGroup.class)
+        .name();
+  }
+
+  protected String getMRGRegionName(FlightContext context) {
+    return getParameterOrThrow(
+            context.getWorkingMap(),
+            GetManagedResourceGroupInfo.TARGET_MRG_KEY,
+            TargetManagedResourceGroup.class)
+        .region();
+  }
+
+  protected ParametersResolver getParametersResolver(FlightContext context) {
+    return getParameterOrThrow(
+        context.getWorkingMap(),
+        LandingZoneFlightMapKeys.CREATE_LANDING_ZONE_PARAMETERS_RESOLVER,
+        ParametersResolver.class);
+  }
+
+  private StepResult handleManagementException(
+      ManagementException e,
+      String landingZoneId,
+      String landingZoneType) {
+    var handled = maybeHandleManagementException(e);
+    if (handled.isPresent()) {
+      var stepResult = handled.get();
+      if (!stepResult.isSuccess()
+          && stepResult.getStepStatus().equals(StepStatus.STEP_RESULT_FAILURE_FATAL)) {
+        MetricUtils.incrementLandingZoneCreationFailure(landingZoneType);
+      }
+      return handled.get();
+    }
+
+    logger.error(
+            FAILED_TO_CREATE_REF_RESOURCE,
+        getArmResourceType(),
+        landingZoneId,
+        ManagementExceptionUtils.buildErrorInfo(e));
+    MetricUtils.incrementLandingZoneCreationFailure(landingZoneType);
+    return new StepResult(
+        StepStatus.STEP_RESULT_FAILURE_FATAL, new FlightExceptionTranslator(e).translate());
+  }
+}

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/BaseReferencedResourceStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/BaseReferencedResourceStep.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.apache.commons.collections4.map.HashedMap;
+import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,7 +102,9 @@ public abstract class BaseReferencedResourceStep implements Step {
 
   private void setLandingZoneResourceTags(FlightContext context, GenericResource genericResource) {
 
-    if (genericResource.tags().containsKey(LandingZoneTagKeys.LANDING_ZONE_ID.toString())) {
+    UUID lzId = getLandingZoneId(context);
+    String lzIdTagValue = genericResource.tags().get(LandingZoneTagKeys.LANDING_ZONE_ID.toString());
+    if (Strings.isNotBlank(lzIdTagValue) && !lzIdTagValue.equalsIgnoreCase(lzId.toString())) {
       throw new RuntimeException("Resource already tagged with a Landing Zone ID");
     }
 

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/BaseReferencedResourceStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/BaseReferencedResourceStep.java
@@ -112,10 +112,7 @@ public abstract class BaseReferencedResourceStep implements Step {
           ResourcePurpose.SHARED_RESOURCE.toString());
     }
 
-    armManagers
-        .azureResourceManager()
-        .tagOperations()
-        .updateTags(genericResource.id(), tagsToApply);
+    armManagers.azureResourceManager().tagOperations().updateTags(genericResource, tagsToApply);
   }
 
   protected abstract boolean isSharedResource();
@@ -125,12 +122,19 @@ public abstract class BaseReferencedResourceStep implements Step {
 
   private Optional<GenericResource> findReferencedResourceByArmResourceType(
       FlightContext flightContext) {
+
+    var fullResourceType = getArmResourceType().toString();
+
+    var providerNamespace = fullResourceType.substring(0, fullResourceType.lastIndexOf('/'));
+    var resourceType = fullResourceType.substring(fullResourceType.lastIndexOf('/') + 1);
+
     for (GenericResource resource :
         armManagers
             .azureResourceManager()
             .genericResources()
             .listByResourceGroup(getMRGName(flightContext))) {
-      if (resource.resourceType().equalsIgnoreCase(getArmResourceType().toString())) {
+      if (resource.resourceType().equalsIgnoreCase(resourceType)
+          && resource.resourceProviderNamespace().equalsIgnoreCase(providerNamespace)) {
         return Optional.of(resource);
       }
     }

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/BaseReferencedResourceStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/BaseReferencedResourceStep.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.apache.commons.collections4.map.HashedMap;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedAksStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedAksStep.java
@@ -4,12 +4,12 @@ import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 
 public class ReferencedAksStep extends SharedReferencedResourceStep {
 
-    public ReferencedAksStep(ArmManagers armManagers) {
-        super(armManagers);
-    }
+  public ReferencedAksStep(ArmManagers armManagers) {
+    super(armManagers);
+  }
 
-    @Override
-    protected ArmResourceType getArmResourceType() {
-        return ArmResourceType.AKS;
-    }
+  @Override
+  protected ArmResourceType getArmResourceType() {
+    return ArmResourceType.AKS;
+  }
 }

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedAksStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedAksStep.java
@@ -1,0 +1,15 @@
+package bio.terra.landingzone.stairway.flight.create.reference.resource.step;
+
+import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
+
+public class ReferencedAksStep extends SharedReferencedResourceStep {
+
+    public ReferencedAksStep(ArmManagers armManagers) {
+        super(armManagers);
+    }
+
+    @Override
+    protected ArmResourceType getArmResourceType() {
+        return ArmResourceType.AKS;
+    }
+}

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedAppInsightsStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedAppInsightsStep.java
@@ -3,12 +3,12 @@ package bio.terra.landingzone.stairway.flight.create.reference.resource.step;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 
 public class ReferencedAppInsightsStep extends SharedReferencedResourceStep {
-    public ReferencedAppInsightsStep(ArmManagers armManagers) {
-        super(armManagers);
-    }
+  public ReferencedAppInsightsStep(ArmManagers armManagers) {
+    super(armManagers);
+  }
 
-    @Override
-    protected ArmResourceType getArmResourceType() {
-        return ArmResourceType.APP_INSIGHTS;
-    }
+  @Override
+  protected ArmResourceType getArmResourceType() {
+    return ArmResourceType.APP_INSIGHTS;
+  }
 }

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedAppInsightsStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedAppInsightsStep.java
@@ -1,0 +1,14 @@
+package bio.terra.landingzone.stairway.flight.create.reference.resource.step;
+
+import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
+
+public class ReferencedAppInsightsStep extends SharedReferencedResourceStep {
+    public ReferencedAppInsightsStep(ArmManagers armManagers) {
+        super(armManagers);
+    }
+
+    @Override
+    protected ArmResourceType getArmResourceType() {
+        return ArmResourceType.APP_INSIGHTS;
+    }
+}

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedBatchStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedBatchStep.java
@@ -3,12 +3,12 @@ package bio.terra.landingzone.stairway.flight.create.reference.resource.step;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 
 public class ReferencedBatchStep extends SharedReferencedResourceStep {
-    public ReferencedBatchStep(ArmManagers armManagers) {
-        super(armManagers);
-    }
+  public ReferencedBatchStep(ArmManagers armManagers) {
+    super(armManagers);
+  }
 
-    @Override
-    protected ArmResourceType getArmResourceType() {
-        return ArmResourceType.BATCH;
-    }
+  @Override
+  protected ArmResourceType getArmResourceType() {
+    return ArmResourceType.BATCH;
+  }
 }

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedBatchStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedBatchStep.java
@@ -1,0 +1,14 @@
+package bio.terra.landingzone.stairway.flight.create.reference.resource.step;
+
+import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
+
+public class ReferencedBatchStep extends SharedReferencedResourceStep {
+    public ReferencedBatchStep(ArmManagers armManagers) {
+        super(armManagers);
+    }
+
+    @Override
+    protected ArmResourceType getArmResourceType() {
+        return ArmResourceType.BATCH;
+    }
+}

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedRelayNamespaceStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedRelayNamespaceStep.java
@@ -10,6 +10,6 @@ public class ReferencedRelayNamespaceStep extends SharedReferencedResourceStep {
 
   @Override
   protected ArmResourceType getArmResourceType() {
-    return ArmResourceType.RELAY;
+    return ArmResourceType.RELAY_NAMESPACE;
   }
 }

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedRelayNamespaceStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedRelayNamespaceStep.java
@@ -4,12 +4,12 @@ import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 
 public class ReferencedRelayNamespaceStep extends SharedReferencedResourceStep {
 
-    public ReferencedRelayNamespaceStep(ArmManagers armManagers) {
-        super(armManagers);
-    }
+  public ReferencedRelayNamespaceStep(ArmManagers armManagers) {
+    super(armManagers);
+  }
 
-    @Override
-    protected ArmResourceType getArmResourceType() {
-        return ArmResourceType.RELAY;
-    }
+  @Override
+  protected ArmResourceType getArmResourceType() {
+    return ArmResourceType.RELAY;
+  }
 }

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedRelayNamespaceStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedRelayNamespaceStep.java
@@ -1,0 +1,15 @@
+package bio.terra.landingzone.stairway.flight.create.reference.resource.step;
+
+import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
+
+public class ReferencedRelayNamespaceStep extends SharedReferencedResourceStep {
+
+    public ReferencedRelayNamespaceStep(ArmManagers armManagers) {
+        super(armManagers);
+    }
+
+    @Override
+    protected ArmResourceType getArmResourceType() {
+        return ArmResourceType.RELAY;
+    }
+}

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedStorageStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedStorageStep.java
@@ -1,0 +1,14 @@
+package bio.terra.landingzone.stairway.flight.create.reference.resource.step;
+
+import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
+
+public class ReferencedStorageStep extends SharedReferencedResourceStep {
+    public ReferencedStorageStep(ArmManagers armManagers) {
+        super(armManagers);
+    }
+
+    @Override
+    protected ArmResourceType getArmResourceType() {
+        return ArmResourceType.STORAGE_ACCOUNT;
+    }
+}

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedStorageStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedStorageStep.java
@@ -3,12 +3,12 @@ package bio.terra.landingzone.stairway.flight.create.reference.resource.step;
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 
 public class ReferencedStorageStep extends SharedReferencedResourceStep {
-    public ReferencedStorageStep(ArmManagers armManagers) {
-        super(armManagers);
-    }
+  public ReferencedStorageStep(ArmManagers armManagers) {
+    super(armManagers);
+  }
 
-    @Override
-    protected ArmResourceType getArmResourceType() {
-        return ArmResourceType.STORAGE_ACCOUNT;
-    }
+  @Override
+  protected ArmResourceType getArmResourceType() {
+    return ArmResourceType.STORAGE_ACCOUNT;
+  }
 }

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedVnetStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedVnetStep.java
@@ -4,41 +4,39 @@ import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.landingzone.library.landingzones.deployment.SubnetResourcePurpose;
 import bio.terra.landingzone.stairway.flight.LandingZoneDefaultParameters;
 import bio.terra.stairway.FlightContext;
-
 import java.util.Map;
 
 public class ReferencedVnetStep extends BaseReferencedResourceStep {
-    public ReferencedVnetStep(ArmManagers armManagers) {
-        super(armManagers);
-    }
+  public ReferencedVnetStep(ArmManagers armManagers) {
+    super(armManagers);
+  }
 
-    @Override
-    protected boolean isSharedResource() {
-        return false;
-    }
+  @Override
+  protected boolean isSharedResource() {
+    return false;
+  }
 
-    @Override
-    protected Map<String, String> getLandingZoneResourceTags(FlightContext context, String resourceId) {
-        //get subnet parameters and set them as tags...
-        return Map.of(
-                SubnetResourcePurpose.POSTGRESQL_SUBNET.toString(),
-                getParametersResolver(context)
-                        .getValue(LandingZoneDefaultParameters.ParametersNames.POSTGRESQL_SUBNET.name()),
-                SubnetResourcePurpose.WORKSPACE_BATCH_SUBNET.toString(),
-                getParametersResolver(context)
-                        .getValue(LandingZoneDefaultParameters.ParametersNames.BATCH_SUBNET.name()),
-                SubnetResourcePurpose.WORKSPACE_COMPUTE_SUBNET.toString(),
-                getParametersResolver(context)
-                        .getValue(LandingZoneDefaultParameters.ParametersNames.COMPUTE_SUBNET.name()),
-                SubnetResourcePurpose.AKS_NODE_POOL_SUBNET.toString(),
-                getParametersResolver(context)
-                        .getValue(LandingZoneDefaultParameters.ParametersNames.AKS_NODE_POOL_SUBNET.name())
-        );
-    }
+  @Override
+  protected Map<String, String> getLandingZoneResourceTags(
+      FlightContext context, String resourceId) {
+    // get subnet parameters and set them as tags...
+    return Map.of(
+        SubnetResourcePurpose.POSTGRESQL_SUBNET.toString(),
+        getParametersResolver(context)
+            .getValue(LandingZoneDefaultParameters.ParametersNames.POSTGRESQL_SUBNET.name()),
+        SubnetResourcePurpose.WORKSPACE_BATCH_SUBNET.toString(),
+        getParametersResolver(context)
+            .getValue(LandingZoneDefaultParameters.ParametersNames.BATCH_SUBNET.name()),
+        SubnetResourcePurpose.WORKSPACE_COMPUTE_SUBNET.toString(),
+        getParametersResolver(context)
+            .getValue(LandingZoneDefaultParameters.ParametersNames.COMPUTE_SUBNET.name()),
+        SubnetResourcePurpose.AKS_NODE_POOL_SUBNET.toString(),
+        getParametersResolver(context)
+            .getValue(LandingZoneDefaultParameters.ParametersNames.AKS_NODE_POOL_SUBNET.name()));
+  }
 
-    @Override
-    protected ArmResourceType getArmResourceType() {
-        return ArmResourceType.VNET;
-    }
+  @Override
+  protected ArmResourceType getArmResourceType() {
+    return ArmResourceType.VNET;
+  }
 }
-

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedVnetStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedVnetStep.java
@@ -21,18 +21,12 @@ public class ReferencedVnetStep extends BaseReferencedResourceStep {
       FlightContext context, String resourceId) {
     // get subnet parameters and set them as tags...
     return Map.of(
-        SubnetResourcePurpose.POSTGRESQL_SUBNET.toString(),
-        getParametersResolver(context)
-            .getValue(LandingZoneDefaultParameters.ParametersNames.POSTGRESQL_SUBNET.name()),
         SubnetResourcePurpose.WORKSPACE_BATCH_SUBNET.toString(),
         getParametersResolver(context)
             .getValue(LandingZoneDefaultParameters.ParametersNames.BATCH_SUBNET.name()),
         SubnetResourcePurpose.WORKSPACE_COMPUTE_SUBNET.toString(),
         getParametersResolver(context)
-            .getValue(LandingZoneDefaultParameters.ParametersNames.COMPUTE_SUBNET.name()),
-        SubnetResourcePurpose.AKS_NODE_POOL_SUBNET.toString(),
-        getParametersResolver(context)
-            .getValue(LandingZoneDefaultParameters.ParametersNames.AKS_NODE_POOL_SUBNET.name()));
+            .getValue(LandingZoneDefaultParameters.ParametersNames.COMPUTE_SUBNET.name()));
   }
 
   @Override

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedVnetStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/ReferencedVnetStep.java
@@ -1,0 +1,44 @@
+package bio.terra.landingzone.stairway.flight.create.reference.resource.step;
+
+import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
+import bio.terra.landingzone.library.landingzones.deployment.SubnetResourcePurpose;
+import bio.terra.landingzone.stairway.flight.LandingZoneDefaultParameters;
+import bio.terra.stairway.FlightContext;
+
+import java.util.Map;
+
+public class ReferencedVnetStep extends BaseReferencedResourceStep {
+    public ReferencedVnetStep(ArmManagers armManagers) {
+        super(armManagers);
+    }
+
+    @Override
+    protected boolean isSharedResource() {
+        return false;
+    }
+
+    @Override
+    protected Map<String, String> getLandingZoneResourceTags(FlightContext context, String resourceId) {
+        //get subnet parameters and set them as tags...
+        return Map.of(
+                SubnetResourcePurpose.POSTGRESQL_SUBNET.toString(),
+                getParametersResolver(context)
+                        .getValue(LandingZoneDefaultParameters.ParametersNames.POSTGRESQL_SUBNET.name()),
+                SubnetResourcePurpose.WORKSPACE_BATCH_SUBNET.toString(),
+                getParametersResolver(context)
+                        .getValue(LandingZoneDefaultParameters.ParametersNames.BATCH_SUBNET.name()),
+                SubnetResourcePurpose.WORKSPACE_COMPUTE_SUBNET.toString(),
+                getParametersResolver(context)
+                        .getValue(LandingZoneDefaultParameters.ParametersNames.COMPUTE_SUBNET.name()),
+                SubnetResourcePurpose.AKS_NODE_POOL_SUBNET.toString(),
+                getParametersResolver(context)
+                        .getValue(LandingZoneDefaultParameters.ParametersNames.AKS_NODE_POOL_SUBNET.name())
+        );
+    }
+
+    @Override
+    protected ArmResourceType getArmResourceType() {
+        return ArmResourceType.VNET;
+    }
+}
+

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/SharedReferencedResourceStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/SharedReferencedResourceStep.java
@@ -2,26 +2,26 @@ package bio.terra.landingzone.stairway.flight.create.reference.resource.step;
 
 import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
 import bio.terra.stairway.FlightContext;
-
 import java.util.Map;
 
 public class SharedReferencedResourceStep extends BaseReferencedResourceStep {
-    protected SharedReferencedResourceStep(ArmManagers armManagers) {
-        super(armManagers);
-    }
+  protected SharedReferencedResourceStep(ArmManagers armManagers) {
+    super(armManagers);
+  }
 
-    @Override
-    protected boolean isSharedResource() {
-        return true;
-    }
+  @Override
+  protected boolean isSharedResource() {
+    return true;
+  }
 
-    @Override
-    protected Map<String, String> getLandingZoneResourceTags(FlightContext context, String resourceId) {
-        return Map.of();
-    }
+  @Override
+  protected Map<String, String> getLandingZoneResourceTags(
+      FlightContext context, String resourceId) {
+    return Map.of();
+  }
 
-    @Override
-    protected ArmResourceType getArmResourceType() {
-        return null;
-    }
+  @Override
+  protected ArmResourceType getArmResourceType() {
+    return null;
+  }
 }

--- a/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/SharedReferencedResourceStep.java
+++ b/library/src/main/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/SharedReferencedResourceStep.java
@@ -1,0 +1,27 @@
+package bio.terra.landingzone.stairway.flight.create.reference.resource.step;
+
+import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
+import bio.terra.stairway.FlightContext;
+
+import java.util.Map;
+
+public class SharedReferencedResourceStep extends BaseReferencedResourceStep {
+    protected SharedReferencedResourceStep(ArmManagers armManagers) {
+        super(armManagers);
+    }
+
+    @Override
+    protected boolean isSharedResource() {
+        return true;
+    }
+
+    @Override
+    protected Map<String, String> getLandingZoneResourceTags(FlightContext context, String resourceId) {
+        return Map.of();
+    }
+
+    @Override
+    protected ArmResourceType getArmResourceType() {
+        return null;
+    }
+}

--- a/library/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/StepsDefinitionFactoryTypeTest.java
+++ b/library/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/StepsDefinitionFactoryTypeTest.java
@@ -30,6 +30,8 @@ class StepsDefinitionFactoryTypeTest {
         Arguments.of("ProtectedDataResourcesFactory"),
         Arguments.of("cromwellbaseresourcesfactory"),
         Arguments.of("protecteddataresourcesfactory"),
+        Arguments.of("ReferencedResourcesFactory"),
+        Arguments.of("REFERENCEDRESOURCESFACTORY"),
         Arguments.of("CROMWELLBASERESOURCESFACTORY"),
         Arguments.of("PROTECTEDDATARESOURCESFACTORY"));
   }

--- a/library/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/validation/ReferencedVNetValidatorTest.java
+++ b/library/src/test/java/bio/terra/landingzone/library/landingzones/definition/factories/validation/ReferencedVNetValidatorTest.java
@@ -1,0 +1,75 @@
+package bio.terra.landingzone.library.landingzones.definition.factories.validation;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import bio.terra.landingzone.library.landingzones.definition.factories.ParametersResolver;
+import bio.terra.landingzone.library.landingzones.definition.factories.exception.InvalidInputParameterException;
+import bio.terra.landingzone.stairway.flight.LandingZoneDefaultParameters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@Tag("unit")
+@ExtendWith(MockitoExtension.class)
+class ReferencedVNetValidatorTest {
+
+  private ReferencedVNetValidator validator;
+
+  @Mock ParametersResolver mockParametersResolver;
+
+  @BeforeEach
+  void setUp() {
+    validator = new ReferencedVNetValidator();
+  }
+
+  @Test
+  void validate_AllParametersProvided_PassesValidation() {
+    when(mockParametersResolver.getValue(
+            LandingZoneDefaultParameters.ParametersNames.BATCH_SUBNET.name()))
+        .thenReturn("batch-subnet");
+    when(mockParametersResolver.getValue(
+            LandingZoneDefaultParameters.ParametersNames.COMPUTE_SUBNET.name()))
+        .thenReturn("compute-subnet");
+    assertDoesNotThrow(() -> validator.validate(mockParametersResolver));
+  }
+
+  @Test
+  void validate_BatchSubnetMissing_ThrowsException() {
+    when(mockParametersResolver.getValue(
+            LandingZoneDefaultParameters.ParametersNames.BATCH_SUBNET.name()))
+        .thenReturn(null);
+    when(mockParametersResolver.getValue(
+            LandingZoneDefaultParameters.ParametersNames.COMPUTE_SUBNET.name()))
+        .thenReturn("compute-subnet");
+    assertThrows(
+        InvalidInputParameterException.class, () -> validator.validate(mockParametersResolver));
+  }
+
+  @Test
+  void validate_ComputeSubnetMissing_ThrowsException() {
+    when(mockParametersResolver.getValue(
+            LandingZoneDefaultParameters.ParametersNames.BATCH_SUBNET.name()))
+        .thenReturn("batch-subnet");
+    when(mockParametersResolver.getValue(
+            LandingZoneDefaultParameters.ParametersNames.COMPUTE_SUBNET.name()))
+        .thenReturn(null);
+    assertThrows(
+        InvalidInputParameterException.class, () -> validator.validate(mockParametersResolver));
+  }
+
+  @Test
+  void validate_AllParametersMissing_ThrowsException() {
+    when(mockParametersResolver.getValue(
+            LandingZoneDefaultParameters.ParametersNames.BATCH_SUBNET.name()))
+        .thenReturn(null);
+    when(mockParametersResolver.getValue(
+            LandingZoneDefaultParameters.ParametersNames.COMPUTE_SUBNET.name()))
+        .thenReturn(null);
+    assertThrows(
+        InvalidInputParameterException.class, () -> validator.validate(mockParametersResolver));
+  }
+}

--- a/library/src/test/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/BaseReferencedResourceStepTest.java
+++ b/library/src/test/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/BaseReferencedResourceStepTest.java
@@ -216,22 +216,25 @@ public class BaseReferencedResourceStepTest {
   }
 
   private void setUpMocks() {
-    workingFlightMap = new FlightMap();
-    when(context.getWorkingMap()).thenReturn(workingFlightMap);
-    workingFlightMap.put(
-        GetManagedResourceGroupInfo.TARGET_MRG_KEY,
-        new TargetManagedResourceGroup("mrg", "armregion"));
+    setUpFlightWorkingMap();
 
     setUpMockFlightParameters();
 
     setUpMockResourceListing();
   }
 
+  private void setUpFlightWorkingMap() {
+    workingFlightMap = new FlightMap();
+    when(context.getWorkingMap()).thenReturn(workingFlightMap);
+    workingFlightMap.put(
+        GetManagedResourceGroupInfo.TARGET_MRG_KEY,
+        new TargetManagedResourceGroup("mrg", "armregion"));
+  }
+
   private void setUpMockResourceListing() {
     lenient().when(armManagers.azureResourceManager()).thenReturn(azureResourceManager);
     lenient().when(azureResourceManager.genericResources()).thenReturn(genericResources);
-    lenient().when(resource.resourceType()).thenReturn("storageAccounts");
-    lenient().when(resource.resourceProviderNamespace()).thenReturn("Microsoft.Storage");
+    lenient().when(resource.type()).thenReturn("Microsoft.Storage/storageAccounts");
     var resources = List.of(resource);
     lenient().when(genericResourcesPage.iterator()).thenReturn(resources.iterator());
     lenient().when(genericResources.listByResourceGroup("mrg")).thenReturn(genericResourcesPage);

--- a/library/src/test/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/BaseReferencedResourceStepTest.java
+++ b/library/src/test/java/bio/terra/landingzone/stairway/flight/create/reference/resource/step/BaseReferencedResourceStepTest.java
@@ -1,0 +1,157 @@
+package bio.terra.landingzone.stairway.flight.create.reference.resource.step;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import bio.terra.landingzone.library.landingzones.definition.ArmManagers;
+import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
+import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
+import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneRequest;
+import bio.terra.landingzone.stairway.common.model.TargetManagedResourceGroup;
+import bio.terra.landingzone.stairway.flight.LandingZoneFlightMapKeys;
+import bio.terra.landingzone.stairway.flight.create.resource.step.GetManagedResourceGroupInfo;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.resourcemanager.AzureResourceManager;
+import com.azure.resourcemanager.monitor.models.TagsResource;
+import com.azure.resourcemanager.resources.models.GenericResource;
+import com.azure.resourcemanager.resources.models.GenericResources;
+import com.azure.resourcemanager.resources.models.TagOperations;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("unit")
+public class BaseReferencedResourceStepTest {
+
+  private static final String RESOURCE_ID = "resourceId";
+
+  @Captor private ArgumentCaptor<Map<String, String>> tagsCaptor;
+
+  private TagsResource tagsResource;
+  @Mock private TagOperations tagOperations;
+  @Mock private ArmManagers armManagers;
+  @Mock private AzureResourceManager azureResourceManager;
+  @Mock private GenericResources genericResources;
+  @Mock private GenericResource resource;
+  @Mock private PagedIterable<GenericResource> genericResourcesPage;
+
+  private Map<String, String> tags;
+  private ArmResourceType armResourceType;
+  private final UUID landingZoneId = UUID.randomUUID();
+
+  @Mock private FlightContext context;
+
+  @BeforeEach
+  void setUp() {
+    armResourceType = ArmResourceType.STORAGE_ACCOUNT;
+    tags = Map.of();
+    setUpMocks();
+  }
+
+  @Test
+  void doStep_resourceTypeIsFound_setsLzTagAndSucceeds() throws InterruptedException {
+    BaseReferencedResourceStep referencedResourceStep =
+        new ReferencedResourceStep(armManagers, tags, armResourceType, false);
+
+    StepResult result = referencedResourceStep.doStep(context);
+
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+
+    // verify the tags captured contain the landing zone id
+    Map<String, String> tags = tagsCaptor.getValue();
+    assertThat(
+        tags.get(LandingZoneTagKeys.LANDING_ZONE_ID.toString()), equalTo(landingZoneId.toString()));
+  }
+
+  protected void verifyBasicTags(Map<String, String> tags, UUID landingZoneId) {
+    // assertNotNull(tags);
+    // assertTrue(tags.containsKey(LandingZoneTagKeys.LANDING_ZONE_ID.toString()));
+    assertThat(
+        tags.get(LandingZoneTagKeys.LANDING_ZONE_ID.toString()), equalTo(landingZoneId.toString()));
+    // assertTrue(tags.containsKey(LandingZoneTagKeys.LANDING_ZONE_PURPOSE.toString()));
+    assertThat(
+        tags.get(LandingZoneTagKeys.LANDING_ZONE_PURPOSE.toString()),
+        equalTo(ResourcePurpose.SHARED_RESOURCE.toString()));
+  }
+
+  private void setUpMocks() {
+    FlightMap flightMap = new FlightMap();
+    when(context.getWorkingMap()).thenReturn(flightMap);
+    flightMap.put(LandingZoneFlightMapKeys.LANDING_ZONE_ID, landingZoneId);
+    flightMap.put(
+        GetManagedResourceGroupInfo.TARGET_MRG_KEY,
+        new TargetManagedResourceGroup("mrg", "armregion"));
+
+    FlightMap parameters = new FlightMap();
+    LandingZoneRequest request =
+        new LandingZoneRequest(
+            "definition", "version", Map.of(), UUID.randomUUID(), Optional.of(landingZoneId));
+    when(context.getInputParameters()).thenReturn(parameters);
+    parameters.put(LandingZoneFlightMapKeys.LANDING_ZONE_CREATE_PARAMS, request);
+
+    when(armManagers.azureResourceManager()).thenReturn(azureResourceManager);
+    when(azureResourceManager.genericResources()).thenReturn(genericResources);
+    when(resource.resourceType()).thenReturn("storageAccounts");
+    when(resource.resourceProviderNamespace()).thenReturn("Microsoft.Storage");
+    var resources = List.of(resource);
+    when(genericResourcesPage.iterator()).thenReturn(resources.iterator());
+    when(genericResources.listByResourceGroup("mrg")).thenReturn(genericResourcesPage);
+    when(azureResourceManager.tagOperations()).thenReturn(tagOperations);
+    when(tagOperations.updateTags(any(GenericResource.class), tagsCaptor.capture()))
+        .thenReturn(null);
+  }
+
+  @Test
+  void undoStep() {}
+
+  // Test implementation of BaseReferencedResourceStep
+  private static class ReferencedResourceStep extends BaseReferencedResourceStep {
+
+    private final Map<String, String> tags;
+    private final ArmResourceType armResourceType;
+    private final boolean isShared;
+
+    public ReferencedResourceStep(
+        ArmManagers armManagers,
+        Map<String, String> tags,
+        ArmResourceType armResourceType,
+        boolean isShared) {
+      super(armManagers);
+      this.tags = tags;
+      this.armResourceType = armResourceType;
+      this.isShared = isShared;
+    }
+
+    @Override
+    protected boolean isSharedResource() {
+      return isShared;
+    }
+
+    @Override
+    protected Map<String, String> getLandingZoneResourceTags(
+        FlightContext context, String resourceId) {
+      return tags;
+    }
+
+    @Override
+    protected ArmResourceType getArmResourceType() {
+      return armResourceType;
+    }
+  }
+}


### PR DESCRIPTION
In this PR: 
-  A new LZ (Landing Zone) definition called “Referenced Landing Zone.”
It is designed for scenarios where data plane resources are deployed via a Service Catalog managed application.
- The definition does not deploy any resources.
Instead, it checks for the existence of the following resources:
AKS cluster, Storage account, Batch account, App Insights, VNet, Azure Relay, PostgreSQL flexible server
It assigns the necessary tags to classify these resources as LZ resources.
- The definition does not impose any constraints on how these resources are configured.