### PR TITLE
[WOR-1824]: Add CSP Header to Swagger Page

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -116,14 +116,14 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.LANDINGZONE_TESTING_PUBLISHER_CLIENT_ID }}
 
       - name: Upload Library Test Reports
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Library Test Reports
           path: library/build/reports/tests
 
       - name: Upload Service Test Reports
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Service Test Reports

--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -217,7 +217,7 @@ jobs:
           ./gradlew --build-cache verifyPacts --scan
       - name: Upload Test Reports
         if: always()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: Test Reports
           path: service/build/reports

--- a/service/src/main/resources/api/swagger-ui.html
+++ b/service/src/main/resources/api/swagger-ui.html
@@ -3,6 +3,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self';">
     <title>Swagger UI</title>
     <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css" >
     <link rel="icon" type="image/png" href="/webjars/swagger-ui-dist/favicon-32x32.png" sizes="32x32" />

--- a/service/src/main/resources/api/swagger-ui.html
+++ b/service/src/main/resources/api/swagger-ui.html
@@ -3,7 +3,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none';">
     <title>Swagger UI</title>
     <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css" >
     <link rel="icon" type="image/png" href="/webjars/swagger-ui-dist/favicon-32x32.png" sizes="32x32" />


### PR DESCRIPTION
**Description:**

This PR adds a Content Security Policy (CSP) header to the Landing Zone Service Swagger page to enhance security by reducing the risk of cross-site scripting (XSS) and data injection attacks.

**Changes:**

- Added CSP header to the Swagger page response using the most common directives:
   - **default-src** _the default policy for loading javascript, images, CSS, fonts, AJAX requests, etc_
   - **script-src** _defines valid sources for javascript files_
   - **style-src** _defines valid sources for CSS files_
   - **img-src** _defines valid sources for images_
   - **connect-src** _defines valid targets for XMLHttpRequest (AJAX), WebSockets, and EventSource._
- Configured the header to allow necessary resources, using `unsafe-inline` to enable inline scripts and styles where needed.
- Updated [artifact-actions to v4](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/)

**Testing:**

- Verified the Swagger page displays correctly with the CSP header.
- Checked for any security warnings or content issues.

<img width="1276" alt="Screenshot 2024-09-27 at 8 15 44 PM" src="https://github.com/user-attachments/assets/c479294a-fa15-46b7-b873-75ee42261fcc">
