### PR TITLE
[WOR-1825] Set Strict-Transport-Security header on LZS responses

### DIFF
--- a/service/src/main/java/bio/terra/lz/futureservice/app/common/http/filter/StrictTransportSecurityHeaderFilter.java
+++ b/service/src/main/java/bio/terra/lz/futureservice/app/common/http/filter/StrictTransportSecurityHeaderFilter.java
@@ -1,0 +1,20 @@
+package bio.terra.lz.futureservice.app.common.http.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class StrictTransportSecurityHeaderFilter extends OncePerRequestFilter {
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    response.setHeader("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload");
+    filterChain.doFilter(request, response);
+  }
+}

--- a/service/src/test/java/bio/terra/lz/futureservice/app/controller/ControllerResponseHeaderTest.java
+++ b/service/src/test/java/bio/terra/lz/futureservice/app/controller/ControllerResponseHeaderTest.java
@@ -30,4 +30,15 @@ public class ControllerResponseHeaderTest {
     assertEquals("no-store", response.getHeaders().getCacheControl());
     assertEquals("no-cache", response.getHeaders().getPragma());
   }
+
+  @Test
+  void listAzureLandingZoneDefinitions_ResponseContainsStrictTransportSecurityHeader() {
+    ResponseEntity<String> response =
+        restTemplate.getForEntity(
+            TestEndpoints.LIST_AZURE_LANDING_ZONES_DEFINITIONS_PATH, String.class);
+
+    assertEquals(
+        "max-age=63072000; includeSubDomains; preload",
+        response.getHeaders().get("Strict-Transport-Security").get(0));
+  }
 }


### PR DESCRIPTION
Ticket: [WOR-1825](https://broadworkbench.atlassian.net/browse/WOR-1825)
* Implementation inspired by Sergiy's approach to set other headers on LZS responses - https://github.com/DataBiosphere/terra-landing-zone-service/pull/478
* Header values taken from https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security#examples and seemed to be a reasonable choice

[WOR-1825]: https://broadworkbench.atlassian.net/browse/WOR-1825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ