### PR TITLE
[CORE-44] Upgrade Base Image to jre:17-12-distroless for Security Fix

### DIFF
--- a/foundation.yaml
+++ b/foundation.yaml
@@ -15,13 +15,13 @@ metadata:
     - dsp
     - terra
     - springboot
-    - broadworkspaces
+    - broad-core-services
   annotations:
     github.com/project-slug: databiosphere/terra-landing-zone-service
 spec:
   type: library
   lifecycle: production
-  owner: broadworkspaces
+  owner: broad-core-services
   system: terra
   dependsOn:
     - component:sam

--- a/service/gradle/publishing.gradle
+++ b/service/gradle/publishing.gradle
@@ -22,7 +22,7 @@ tasks.register('extractProfilerAgent', Copy) {
 jib {
     from {
         // see https://github.com/broadinstitute/dsp-appsec-blessed-images/tree/main/jre
-        image = "us.gcr.io/broad-dsp-gcr-public/base/jre:17-distroless"
+        image = "us.gcr.io/broad-dsp-gcr-public/base/jre:17-12-distroless"
     }
     extraDirectories {
         paths = [file(jibExtraDirectory)]


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-44

**Description:**

This PR upgrades the base image from jre:17-distroless to jre:17-12-distroless to fix a security vulnerability. Service compatibility has been checked, and tests have been run to ensure everything works as expected.

It also includes an update of the codebase owner to the new team: `broad-core-services`

**Infosec Discussion:**

Reference: [Message from David Bernick in #dsp-engineering.](https://broadinstitute.slack.com/archives/C0DSD41QT/p1728328182615109)