### PR TITLE
[CORE-69] Move automatic dependency updates to CORE from Workspaces

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,12 +19,12 @@ updates:
       timezone: "America/New_York"
     target-branch: "main"
     reviewers:
-      - "@DataBiosphere/broadworkspaces"
+      - "@DataBiosphere/broad-core-services"
     labels:
       - "dependency"
       - "gradle"
     commit-message:
-      prefix: "[WOR-1448]"
+      prefix: "[CORE-69]"
     ignore:
       # From 20.0.0 onward, k8s client publishes versions with and without '-legacy' suffix.
       # We use the non-legacy client: the legacy client is not compatible with our code.


### PR DESCRIPTION
Dependabot automatically tags an associated ticket and the workspaces team. The ticket was moved from WS to CORE; this PR updates the ticket and which team is tagged on dependabot updates.