### PR TITLE
[CORE-275] Use correct value for azureEnvironment

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -34,7 +34,7 @@ spring:
 #since LZ is amalgamated we need to inherit "workspace" prefix. later it should be changed to landingzone.
 workspace:
   azure:
-    azureEnvironment: AZURE
+    azureEnvironment: AzureCloud
   ingress:
     # Default value that's overridden by Helm.
     domain-name: localhost:8080


### PR DESCRIPTION
Ticket: [CORE-275](https://broadworkbench.atlassian.net/browse/CORE-275)
* Set correct Azure environment for case statement in `AzureConfiguration` which looks for "AzureCloud" not "AZURE" ([source](https://github.com/DataBiosphere/terra-landing-zone-service/blob/76621c4fe642e617daa8e12a136ce24bb61601b8/library/src/main/java/bio/terra/landingzone/library/configuration/LandingZoneAzureConfiguration.java#L42-L44))

[CORE-275]: https://broadworkbench.atlassian.net/browse/CORE-275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ