### PR TITLE
CORE-391: update TCL and k8s client

### DIFF
--- a/buildSrc/src/main/groovy/bio.terra.landingzone.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.landingzone.java-common-conventions.gradle
@@ -47,7 +47,7 @@ repositories {
 dependencies {
     compileOnly "com.google.code.findbugs:annotations:3.0.1"
     implementation 'io.swagger.core.v3:swagger-annotations:2.1.12'
-    implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.2.0'
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.12.0'
     // Needed for @VisibleForTesting and more:
     // TCL 1.0.10 tries to expose this as an api dependency, but does so without specifying an explicit version
     // (it derives the version from com.google.cloud:libraries-bom, which it doesn't expose to consumers).

--- a/buildSrc/src/main/groovy/bio.terra.landingzone.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.landingzone.java-common-conventions.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation 'com.google.guava:guava:33.1.0-jre'
     swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.47'
 
-    implementation ('bio.terra:terra-common-lib:1.1.11-SNAPSHOT') {
+    implementation ('bio.terra:terra-common-lib:1.1.38-SNAPSHOT') {
         exclude group: "org.broadinstitute.dsde.workbench", module: "sam-client_2.13"
     }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -39,7 +39,9 @@ dependencies {
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-applicationinsights', version: '1.1.0'
     implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-securityinsights', version: '1.0.0-beta.5'
 
-    implementation group: "io.kubernetes", name: "client-java", version: "20.0.1" // Do not use -legacy versions
+    // Should match the version used in terra-common-lib
+    // Do not use -legacy versions
+    implementation group: "io.kubernetes", name: "client-java", version: "23.0.0"
     constraints {
         implementation('org.bouncycastle:bcprov-jdk18on:1.80') {
             because 'https://broadworkbench.atlassian.net/browse/WOR-1650'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation 'org.springframework:spring-aspects'
     //we need to expose it at service module for status checking capability
     api 'org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-6d19a41'
-    implementation 'bio.terra:billing-profile-manager-client:0.1.484-SNAPSHOT'
+    implementation 'bio.terra:billing-profile-manager-client:0.1.611-SNAPSHOT'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api'
     implementation group: 'com.azure', name: 'azure-core', version: '1.55.3'
     implementation (group: 'com.azure', name: 'azure-identity', version: '1.15.4') {

--- a/library/src/main/java/bio/terra/landingzone/library/configuration/stairway/LandingZoneStairwayConfiguration.java
+++ b/library/src/main/java/bio/terra/landingzone/library/configuration/stairway/LandingZoneStairwayConfiguration.java
@@ -35,6 +35,6 @@ public class LandingZoneStairwayConfiguration {
     stairwayProperties.setGcpPubSubTopicId(landingZoneStairwayProperties.getGcpPubSubTopicId());
     stairwayProperties.setGcpPubSubSubscriptionId(
         landingZoneStairwayProperties.getGcpPubSubSubscriptionId());
-    return new StairwayComponent(kubeService, kubeProperties, stairwayProperties);
+    return new StairwayComponent(kubeService, kubeProperties, stairwayProperties, stairwayProperties.stairwayExecutor());
   }
 }

--- a/library/src/main/java/bio/terra/landingzone/library/configuration/stairway/LandingZoneStairwayConfiguration.java
+++ b/library/src/main/java/bio/terra/landingzone/library/configuration/stairway/LandingZoneStairwayConfiguration.java
@@ -35,6 +35,8 @@ public class LandingZoneStairwayConfiguration {
     stairwayProperties.setGcpPubSubTopicId(landingZoneStairwayProperties.getGcpPubSubTopicId());
     stairwayProperties.setGcpPubSubSubscriptionId(
         landingZoneStairwayProperties.getGcpPubSubSubscriptionId());
-    return new StairwayComponent(kubeService, kubeProperties, stairwayProperties, stairwayProperties.stairwayExecutor());
+
+    return new StairwayComponent(
+        kubeService, kubeProperties, stairwayProperties, stairwayProperties.stairwayExecutor());
   }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-391

Update terra-common-lib 1.1.11 -> 1.1.38
Update k8s client-java 20.0.1 -> 23.0.0, which matches the version in TCL 1.1.38