### PR TITLE
CORE-391: update to latest Sam client; MockBean->MockitoBean

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation 'org.springframework:spring-aop'
     implementation 'org.springframework:spring-aspects'
     //we need to expose it at service module for status checking capability
-    api 'org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-6d19a41'
+    api 'org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.371'
     implementation 'bio.terra:billing-profile-manager-client:0.1.611-SNAPSHOT'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api'
     implementation group: 'com.azure', name: 'azure-core', version: '1.55.3'

--- a/library/src/main/java/bio/terra/landingzone/service/iam/LandingZoneSamService.java
+++ b/library/src/main/java/bio/terra/landingzone/service/iam/LandingZoneSamService.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.BooleanUtils;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
-import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyMembershipV2;
+import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyMembershipRequest;
 import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
 import org.broadinstitute.dsde.workbench.client.sam.model.FullyQualifiedResourceId;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserResourcesResponse;
@@ -104,16 +104,16 @@ public class LandingZoneSamService {
             .resourceId(billingProfileId.toString())
             .resourceTypeName(SamConstants.SamResourceType.SPEND_PROFILE);
 
-    Map<String, AccessPolicyMembershipV2> policies = new HashMap<>();
+    Map<String, AccessPolicyMembershipRequest> policies = new HashMap<>();
     policies.put(
         "owner",
-        new AccessPolicyMembershipV2()
+        new AccessPolicyMembershipRequest()
             .addMemberEmailsItem(userInfo.getUserEmail())
             .addRolesItem(SamConstants.SamRole.OWNER));
     if (CollectionUtils.isNotEmpty(samClient.getLandingZoneResourceUsers())) {
       policies.put(
           "user",
-          new AccessPolicyMembershipV2()
+          new AccessPolicyMembershipRequest()
               .memberEmails(samClient.getLandingZoneResourceUsers())
               .addRolesItem(SamConstants.SamRole.USER));
     }

--- a/library/src/test/java/bio/terra/landingzone/service/iam/LandingZoneSamServiceTest.java
+++ b/library/src/test/java/bio/terra/landingzone/service/iam/LandingZoneSamServiceTest.java
@@ -24,7 +24,7 @@ import org.apache.http.HttpStatus;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
-import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyMembershipV2;
+import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyMembershipRequest;
 import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
 import org.broadinstitute.dsde.workbench.client.sam.model.FullyQualifiedResourceId;
 import org.broadinstitute.dsde.workbench.client.sam.model.RolesAndActions;
@@ -150,15 +150,15 @@ class LandingZoneSamServiceTest {
   @Test
   void createLandingZone_success() throws ApiException, InterruptedException {
     var listOfUsers = List.of(SAM_USER.getEmail());
-    Map<String, AccessPolicyMembershipV2> policies = new HashMap<>();
+    Map<String, AccessPolicyMembershipRequest> policies = new HashMap<>();
     policies.put(
         "owner",
-        new AccessPolicyMembershipV2()
+        new AccessPolicyMembershipRequest()
             .addMemberEmailsItem(SAM_USER.getEmail())
             .addRolesItem(SamConstants.SamRole.OWNER));
     policies.put(
         "user",
-        new AccessPolicyMembershipV2()
+        new AccessPolicyMembershipRequest()
             .memberEmails(listOfUsers)
             .addRolesItem(SamConstants.SamRole.USER));
     // Setup Mocks
@@ -176,10 +176,10 @@ class LandingZoneSamServiceTest {
   @Test
   void createLandingZone_noUsersInConfig() throws ApiException, InterruptedException {
     var listOfUsers = Collections.EMPTY_LIST;
-    Map<String, AccessPolicyMembershipV2> policies = new HashMap<>();
+    Map<String, AccessPolicyMembershipRequest> policies = new HashMap<>();
     policies.put(
         "owner",
-        new AccessPolicyMembershipV2()
+        new AccessPolicyMembershipRequest()
             .addMemberEmailsItem(SAM_USER.getEmail())
             .addRolesItem(SamConstants.SamRole.OWNER));
     // Setup Mocks
@@ -351,7 +351,7 @@ class LandingZoneSamServiceTest {
                 .enabled(enabled));
   }
 
-  private void verifyCreateResourceV2(Map<String, AccessPolicyMembershipV2> policies)
+  private void verifyCreateResourceV2(Map<String, AccessPolicyMembershipRequest> policies)
       throws ApiException {
     verify(resourcesApi)
         .createResourceV2(

--- a/library/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
+++ b/library/src/test/java/bio/terra/landingzone/stairway/flight/create/CreateLandingZoneResourcesFlightIntegrationTest.java
@@ -40,10 +40,10 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
@@ -71,7 +71,7 @@ public class CreateLandingZoneResourcesFlightIntegrationTest extends BaseIntegra
   private static final int LZ_DELETED_AWAIT_TIMEOUT_MINUTES = 20;
 
   @Mock private BearerToken bearerToken;
-  @MockBean private LandingZoneDao landingZoneDao;
+  @MockitoBean private LandingZoneDao landingZoneDao;
 
   @Autowired LandingZoneService landingZoneService;
   @Autowired LandingZoneJobService azureLandingZoneJobService;

--- a/service/src/main/java/bio/terra/lz/futureservice/app/service/status/BaseStatusService.java
+++ b/service/src/main/java/bio/terra/lz/futureservice/app/service/status/BaseStatusService.java
@@ -4,6 +4,7 @@ import bio.terra.lz.futureservice.app.configuration.StatusCheckConfiguration;
 import bio.terra.lz.futureservice.generated.model.ApiSystemStatus;
 import bio.terra.lz.futureservice.generated.model.ApiSystemStatusSystems;
 import com.google.common.annotations.VisibleForTesting;
+import jakarta.annotation.PostConstruct;
 import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -13,7 +14,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import javax.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/service/src/test/java/bio/terra/lz/futureservice/app/controller/LandingZoneApiControllerTest.java
+++ b/service/src/test/java/bio/terra/lz/futureservice/app/controller/LandingZoneApiControllerTest.java
@@ -46,9 +46,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultMatcher;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -64,7 +64,7 @@ public class LandingZoneApiControllerTest extends BaseSpringUnitTest {
   @Autowired private MockMvc mockMvc;
   @Autowired private ObjectMapper objectMapper;
 
-  @MockBean LandingZoneAppService mockLandingZoneAppService;
+  @MockitoBean LandingZoneAppService mockLandingZoneAppService;
 
   @Test
   public void createAzureLandingZoneJobRunning() throws Exception {

--- a/service/src/test/java/bio/terra/lz/futureservice/app/controller/PublicApiControllerTest.java
+++ b/service/src/test/java/bio/terra/lz/futureservice/app/controller/PublicApiControllerTest.java
@@ -15,9 +15,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
@@ -33,7 +33,7 @@ public class PublicApiControllerTest extends BaseSpringUnitTest {
   @Autowired private MockMvc mockMvc;
   @Autowired private ObjectMapper objectMapper;
 
-  @MockBean StatusService mockStatusService;
+  @MockitoBean StatusService mockStatusService;
 
   @TestConfiguration
   // this configuration is used only by testServiceVersionSuccess test.

--- a/service/src/test/java/bio/terra/lz/futureservice/pact/consumer/SamServiceConsumerPactTest.java
+++ b/service/src/test/java/bio/terra/lz/futureservice/pact/consumer/SamServiceConsumerPactTest.java
@@ -76,7 +76,8 @@ public class SamServiceConsumerPactTest {
         new PactDslJsonBody()
             .stringType("userSubjectId")
             .stringType("userEmail")
-            .booleanType("enabled");
+            .booleanType("enabled")
+            .booleanType("adminEnabled");
     return builder
         .given("user status info request with access token")
         .uponReceiving("a request for the user's status")

--- a/service/src/test/java/bio/terra/lz/futureservice/pact/consumer/SamServiceConsumerPactTest.java
+++ b/service/src/test/java/bio/terra/lz/futureservice/pact/consumer/SamServiceConsumerPactTest.java
@@ -46,7 +46,7 @@ public class SamServiceConsumerPactTest {
         .method("GET")
         .willRespondWith()
         .status(200)
-        .body(new PactDslJsonBody().booleanValue("ok", true))
+        .body(new PactDslJsonBody().booleanValue("ok", true).object("systems"))
         .toPact();
   }
 

--- a/service/src/test/java/bio/terra/lz/futureservice/pact/provider/LandingZoneServicePactProviderTest.java
+++ b/service/src/test/java/bio/terra/lz/futureservice/pact/provider/LandingZoneServicePactProviderTest.java
@@ -50,7 +50,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 /**
@@ -71,10 +71,10 @@ import org.springframework.test.web.servlet.MockMvc;
 public class LandingZoneServicePactProviderTest extends BaseSpringUnitTest {
   private static final String CONSUMER_BRANCH = System.getenv("CONSUMER_BRANCH");
 
-  @MockBean BearerTokenFactory bearerTokenFactory;
-  @MockBean LandingZoneAppService landingZoneAppService;
-  @MockBean LandingZoneJobService landingZoneJobService;
-  @MockBean StatusService statusService;
+  @MockitoBean BearerTokenFactory bearerTokenFactory;
+  @MockitoBean LandingZoneAppService landingZoneAppService;
+  @MockitoBean LandingZoneJobService landingZoneJobService;
+  @MockitoBean StatusService statusService;
   @Autowired private MockMvc mockMvc;
 
   @PactBrokerConsumerVersionSelectors


### PR DESCRIPTION
#546, as part of upgrading terra-common-lib, upgraded Spring Boot.

The newer version of Spring Boot deprecates `@MockBean` in favor of `@MockitoBean` and logs warnings during compilation when `@MockBean` is used.

This PR switches all usages of `@MockBean` to `@MockitoBean`.

It also updates the Sam client library version. The version previously used was very old. The newer version requires some syntax changes for compatibility.