### PR TITLE
CORE-376: turn off double-tracing and 'failed to export spans' error

### DIFF
--- a/buildSrc/src/main/groovy/bio.terra.landingzone.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.landingzone.java-common-conventions.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation 'com.google.guava:guava:33.1.0-jre'
     swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.47'
 
-    implementation ('bio.terra:terra-common-lib:1.1.38-SNAPSHOT') {
+    implementation ('bio.terra:terra-common-lib:1.1.39-SNAPSHOT') {
         exclude group: "org.broadinstitute.dsde.workbench", module: "sam-client_2.13"
     }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-376

Update TCL to get its fix for the "failed to export spans" error.

See https://github.com/DataBiosphere/terra-common-lib/pull/229